### PR TITLE
feat: add webhook support for monitor status alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ upkit status 1
 - **Live Dashboard** - Real-time TUI with status, latency, and uptime metrics
 - **Multi-Protocol** - HTTP/HTTPS, ICMP Ping, and DNS monitoring
 - **Desktop Notifications** - Get notified when monitors go down or come back up
+- **Webhook Alerts** - Send status updates to custom webhook URLs
 - **Rich Metrics** - Latency sparklines, P95, status history timeline
 - **Lightweight** - Minimal resource usage with SQLite storage
 
@@ -96,6 +97,7 @@ upkit notif status       # alias
 - `-i, --interval` - Check interval in seconds (default: 60)
 - `-n, --name` - Custom name
 - `-u, --url` - URL/Host (for `edit` command)
+- `-w, --webhook` - Webhook URL to receive status updates
 
 ## Monitor Types
 
@@ -114,11 +116,49 @@ upkit add 8.8.8.8 -t icmp -i 10
 upkit add google.com -t dns -i 60
 ```
 
+## Webhooks
+
+Configure webhook URLs to receive HTTP POST notifications when monitors change status (UP/DOWN).
+
+### Webhook Payload
+
+When a monitor's status changes, UptimeKit sends a POST request with the following JSON payload:
+
+```json
+{
+  "event": "monitor_up" ,
+  "monitor": {
+    "name": "My Website",
+    "url": "https://example.com",
+    "status": "up",
+    "time": "2025-11-27T15:40:59.403Z"
+  }
+}
+```
+
+The `event` field will be either `monitor_up` or `monitor_down`.
+
+### Usage
+
+```bash
+# Add monitor with webhook
+upkit add https://mysite.com -t http -n "My Site" -w https://webhook.site/your-id
+
+# Add webhook to existing monitor
+upkit edit 1 -w https://discord.com/api/webhooks/123/abc
+
+# Remove webhook
+upkit edit 1 -w none
+```
+
 ## Examples
 
 ```bash
 # Monitor a website every 30 seconds
 upkit add https://mysite.com -t http -i 30 -n "My Website"
+
+# Monitor with webhook notifications
+upkit add https://mysite.com -t http -i 30 -n "My Website" -w https://webhook.site/your-webhook-id
 
 # Ping Google DNS every 10 seconds
 upkit add 8.8.8.8 -t icmp -i 10 -n "Google DNS"
@@ -157,6 +197,7 @@ The detail view includes:
 - Latency sparkline (last 60 seconds)
 - Current, average, and P95 latency
 - 24-hour uptime percentage
+- Configured webhook URL (if set)
 
 
 ## Requirements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uptimekit",
-  "version": "1.2.14",
+  "version": "1.2.16",
   "description": "A cross-platform CLI for monitoring website/server health with a TUI dashboard.",
   "main": "dist/index.js",
   "type": "module",

--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -17,6 +17,7 @@ export function registerAddCommand(program) {
     .option('-t, --type <type>', 'Type of monitor (http, icmp, dns)')
     .option('-i, --interval <seconds>', 'Check interval in seconds', '60')
     .option('-n, --name <name>', 'Custom name for monitor')
+    .option('-w, --webhook <url>', 'Webhook URL for notifications')
     .action(async (url, options, cmd) => {
       try {
         const allowedTypes = ['http', 'icmp', 'dns'];
@@ -130,7 +131,7 @@ export function registerAddCommand(program) {
           }
         }
 
-        addMonitor(data.type, data.url, data.interval, name);
+        addMonitor(data.type, data.url, data.interval, name, options.webhook);
         console.log(chalk.green(`Monitor added: ${name} (${data.url}, ${data.type})`));
       } catch (err) {
         if (err instanceof z.ZodError) {

--- a/src/commands/edit.js
+++ b/src/commands/edit.js
@@ -7,7 +7,8 @@ const MonitorSchema = z.object({
     url: z.string().min(1).optional(),
     type: z.enum(['http', 'icmp', 'dns']).optional(),
     interval: z.number().min(1).optional(),
-    name: z.string().optional()
+    name: z.string().optional(),
+    webhook_url: z.string().nullable().optional()
 });
 
 export function registerEditCommand(program) {
@@ -18,6 +19,7 @@ export function registerEditCommand(program) {
         .option('-t, --type <type>', 'New type (http, icmp, dns)')
         .option('-i, --interval <seconds>', 'New interval in seconds')
         .option('-n, --name <name>', 'New name')
+        .option('-w, --webhook <url>', 'New webhook URL')
         .action(async (idOrName, options) => {
             try {
                 await initDB();
@@ -35,6 +37,7 @@ export function registerEditCommand(program) {
                 if (options.type) updates.type = options.type;
                 if (options.interval) updates.interval = parseInt(options.interval, 10);
                 if (options.name) updates.name = options.name;
+                if (options.webhook) updates.webhook_url = options.webhook;
 
                 // If no flags provided, go interactive
                 if (Object.keys(updates).length === 0) {
@@ -55,6 +58,12 @@ export function registerEditCommand(program) {
 
                     const newInterval = await question(`Interval [${monitor.interval}]: `);
                     if (newInterval.trim()) updates.interval = parseInt(newInterval.trim(), 10);
+
+                    const currentWebhook = monitor.webhook_url || 'none';
+                    const newWebhook = await question(`Webhook URL [${currentWebhook}]: `);
+                    if (newWebhook.trim()) {
+                        updates.webhook_url = newWebhook.trim() === 'none' ? null : newWebhook.trim();
+                    }
 
                     rl.close();
                 }

--- a/src/core/notifier.js
+++ b/src/core/notifier.js
@@ -1,9 +1,30 @@
 import notifier from 'node-notifier';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import axios from 'axios';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+export async function sendWebhook(webhookUrl, event, monitor) {
+    if (!webhookUrl) return;
+
+    try {
+        const payload = {
+            event: event,
+            monitor: {
+                name: monitor.name,
+                url: monitor.url,
+                status: event === 'monitor_down' ? 'down' : 'up',
+                time: new Date().toISOString()
+            }
+        };
+
+        await axios.post(webhookUrl, payload);
+    } catch (error) {
+        console.error(`Failed to send webhook to ${webhookUrl}:`, error.message);
+    }
+}
 
 export function sendNotification(title, message, options = {}) {
     try {
@@ -24,20 +45,28 @@ export function sendNotification(title, message, options = {}) {
     }
 }
 
-export function notifyMonitorDown(monitorName, monitorUrl) {
-    const displayName = monitorName || monitorUrl;
+export function notifyMonitorDown(monitor) {
+    const displayName = monitor.name || monitor.url;
     sendNotification(
         '❌ Monitor Down',
         `${displayName} is not responding`,
         { sound: true }
     );
+
+    if (monitor.webhook_url) {
+        sendWebhook(monitor.webhook_url, 'monitor_down', monitor);
+    }
 }
 
-export function notifyMonitorUp(monitorName, monitorUrl) {
-    const displayName = monitorName || monitorUrl;
+export function notifyMonitorUp(monitor) {
+    const displayName = monitor.name || monitor.url;
     sendNotification(
         '✅ Monitor Back Up',
         `${displayName} is now responding`,
         { sound: true }
     );
+
+    if (monitor.webhook_url) {
+        sendWebhook(monitor.webhook_url, 'monitor_up', monitor);
+    }
 }

--- a/src/daemon/worker.js
+++ b/src/daemon/worker.js
@@ -52,9 +52,9 @@ async function checkMonitor(monitor) {
     const notificationsEnabled = getNotificationSettings();
     if (notificationsEnabled) {
       if (status === 'down') {
-        notifyMonitorDown(monitor.name, monitor.url);
+        notifyMonitorDown(monitor);
       } else if (status === 'up') {
-        notifyMonitorUp(monitor.name, monitor.url);
+        notifyMonitorUp(monitor);
       }
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ program.configureOutput({
 program
   .name('uptimekit')
   .description('UptimeKit CLI - Monitor your services from the terminal')
-  .version('1.2.14', '-v, --version');
+  .version('1.2.16', '-v, --version');
 
 registerStartCommand(program);  // alias
 registerStopCommand(program);   // alias

--- a/src/ui/MonitorDetail.js
+++ b/src/ui/MonitorDetail.js
@@ -141,6 +141,11 @@ export default function MonitorDetail({ idOrName }) {
                         <Text color="cyan">{monitor.url}</Text>
                     </Box>
                     <Text color="gray" dimColor>Type: {monitor.type} • Interval: {monitor.interval}s</Text>
+                    {monitor.webhook_url && (
+                        <Text color="gray" dimColor>
+                            Webhook: {monitor.webhook_url.length > 50 ? monitor.webhook_url.substring(0, 47) + '...' : monitor.webhook_url}
+                        </Text>
+                    )}
                 </Box>
                 <Box flexDirection="column" alignItems="flex-end">
                     <Text color="gray" dimColor>ID: {monitor.id}</Text>


### PR DESCRIPTION
- Add webhook URL option to add/edit commands (-w, --webhook)
- Send HTTP POST notifications on monitor status changes (up/down)
- Display webhook URL in monitor detail
- Update README with webhook documentation and examples
- Bump version to 1.2.16