### PR TITLE
Feature/notify when retries reached

### DIFF
--- a/.changeset/tender-taxis-kick.md
+++ b/.changeset/tender-taxis-kick.md
@@ -1,0 +1,5 @@
+---
+'uptimekit': minor
+---
+
+Allow specification of retries (monitor add/edit --retries,-r) before a notification is sent

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{js,jsx,ts,tsx}]
+indent_style = space
+indent_size = 2
+tab_width = 2

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+    "tabWidth": 2,
+    "singleQuote": true,
+    "semi": true,
+    "trailingComma": "none",
+    "printWidth": 120,
+    "arrowParens": "avoid"
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,25 +1,21 @@
 export default {
   testEnvironment: 'node',
   transform: {
-    '^.+\\.(js|jsx)$': 'babel-jest',
+    '^.+\\.(js|jsx)$': 'babel-jest'
   },
   moduleFileExtensions: ['js', 'jsx', 'json'],
   testMatch: ['**/__tests__/**/*.test.js', '**/*.test.js'],
   setupFilesAfterEnv: ['<rootDir>/tests/setup.js'],
-  collectCoverageFrom: [
-    'src/**/*.js',
-    '!src/index.js',
-    '!src/daemon/worker.js',
-  ],
+  collectCoverageFrom: ['src/**/*.js', '!src/index.js', '!src/daemon/worker.js'],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov', 'html'],
   moduleNameMapper: {
-    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^(\\.{1,2}/.*)\\.js$': '$1'
   },
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   snapshotSerializers: [],
   verbose: true,
   forceExit: true,
   testTimeout: 10000,
-  detectOpenHandles: false,
+  detectOpenHandles: false
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "uptimekit",
-  "version": "1.2.27",
+  "version": "1.2.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "uptimekit",
-      "version": "1.2.27",
+      "version": "1.2.28",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",
@@ -33,7 +33,8 @@
         "@babel/preset-react": "^7.28.5",
         "@changesets/cli": "^2.29.8",
         "ink-testing-library": "^4.0.0",
-        "jest": "^30.2.0"
+        "jest": "^30.2.0",
+        "prettier": "^3.7.4"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -2006,6 +2007,22 @@
         "semver": "^7.5.3"
       }
     },
+    "node_modules/@changesets/apply-release-plan/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/@changesets/assemble-release-plan": {
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.9.tgz",
@@ -2261,6 +2278,22 @@
         "fs-extra": "^7.0.1",
         "human-id": "^4.1.1",
         "prettier": "^2.7.1"
+      }
+    },
+    "node_modules/@changesets/write/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@emnapi/core": {
@@ -8103,16 +8136,16 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
+      "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch --no-colors",
     "test:coverage": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage --no-colors",
     "test:update-snapshots": "node --experimental-vm-modules node_modules/jest/bin/jest.js --updateSnapshot --no-colors",
+    "format": "prettier --write \"src/**/*.js\" \"tests/**/*.js\" jest.config.js",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "npm run build && changeset publish"
@@ -67,6 +68,7 @@
     "@babel/preset-react": "^7.28.5",
     "@changesets/cli": "^2.29.8",
     "ink-testing-library": "^4.0.0",
-    "jest": "^30.2.0"
+    "jest": "^30.2.0",
+    "prettier": "^3.7.4"
   }
 }

--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -6,7 +6,8 @@ import readline from 'readline';
 const MonitorSchema = z.object({
   url: z.string().min(1),
   type: z.enum(['http', 'icmp', 'dns', 'ssl']),
-  interval: z.number().int().min(1).positive()
+  interval: z.number().int().min(1),
+  retries: z.number().int().min(0).optional()
 });
 
 export function registerAddCommand(program) {
@@ -15,10 +16,11 @@ export function registerAddCommand(program) {
     .description('Add a new monitor')
     .addHelpText(
       'after',
-      '\n\nExamples:\n  uptimekit add https://example2.com -t http -i 30 -n newsite\n  uptimekit add google.com -t dns -i 60 -n googledns\n  uptimekit add example.com -t ssl -i 3600 -n myssl\n  uptimekit add https://api.dev.com -t http -i 30 -n "dev-api" -g dev\n'
+      '\n\nExamples:\n  uptimekit add https://example2.com -t http -i 30 -n newsite\n  uptimekit add https://tworetries.com -t http -i 30 -r2 -n tworetries\n  uptimekit add google.com -t dns -i 60 -n googledns\n  uptimekit add example.com -t ssl -i 3600 -n myssl\n  uptimekit add https://api.dev.com -t http -i 30 -n "dev-api" -g dev\n'
     )
     .option('-t, --type <type>', 'Type of monitor (http, icmp, dns, ssl)')
     .option('-i, --interval <seconds>', 'Check interval in seconds', '60')
+    .option('-r, --retries <number>', 'Check retries before notifications are send', '0')
     .option('-n, --name <name>', 'Custom name for monitor')
     .option('-w, --webhook <url>', 'Webhook URL for notifications')
     .option('-g, --group <group>', 'Group name for organizing monitors (e.g., dev, prod, staging)')
@@ -37,7 +39,10 @@ export function registerAddCommand(program) {
         }
 
         let finalUrl = url;
-        const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+        const rl = readline.createInterface({
+          input: process.stdin,
+          output: process.stdout
+        });
         const question = q => new Promise(resolve => rl.question(q, ans => resolve(ans)));
 
         // sometimes people type 'add add google.com' by mistake, let's catch that
@@ -160,11 +165,15 @@ export function registerAddCommand(program) {
 
         rl.close();
         await initDB();
+
         const interval = parseInt(options.interval, 10);
+        const retries = options.retries !== undefined ? parseInt(options.retries, 10) : undefined;
+
         const data = MonitorSchema.parse({
           url: finalUrl,
           type: options.type,
-          interval
+          interval,
+          retries
         });
 
         let name = options.name;
@@ -181,9 +190,14 @@ export function registerAddCommand(program) {
         }
 
         const groupName = options.group || null;
-        addMonitor(data.type, data.url, data.interval, name, options.webhook, groupName);
+        addMonitor(data.type, data.url, data.interval, data.retries ?? 0, name, options.webhook, groupName);
 
         let successMsg = `Monitor added: ${name} (${data.url}, ${data.type})`;
+
+        if (retries) {
+          successMsg += ` Retries: ${retries}`;
+        }
+
         if (groupName) {
           successMsg += ` [Group: ${groupName}]`;
         }

--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -13,7 +13,10 @@ export function registerAddCommand(program) {
   program
     .command('add <url>')
     .description('Add a new monitor')
-    .addHelpText('after', '\n\nExamples:\n  uptimekit add https://example2.com -t http -i 30 -n newsite\n  uptimekit add google.com -t dns -i 60 -n googledns\n  uptimekit add example.com -t ssl -i 3600 -n myssl\n  uptimekit add https://api.dev.com -t http -i 30 -n "dev-api" -g dev\n')
+    .addHelpText(
+      'after',
+      '\n\nExamples:\n  uptimekit add https://example2.com -t http -i 30 -n newsite\n  uptimekit add google.com -t dns -i 60 -n googledns\n  uptimekit add example.com -t ssl -i 3600 -n myssl\n  uptimekit add https://api.dev.com -t http -i 30 -n "dev-api" -g dev\n'
+    )
     .option('-t, --type <type>', 'Type of monitor (http, icmp, dns, ssl)')
     .option('-i, --interval <seconds>', 'Check interval in seconds', '60')
     .option('-n, --name <name>', 'Custom name for monitor')
@@ -35,14 +38,16 @@ export function registerAddCommand(program) {
 
         let finalUrl = url;
         const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-        const question = (q) => new Promise(resolve => rl.question(q, ans => resolve(ans)));
+        const question = q => new Promise(resolve => rl.question(q, ans => resolve(ans)));
 
         // sometimes people type 'add add google.com' by mistake, let's catch that
         if (cmd && cmd.args && cmd.args.length > 1) {
           const extraArg = cmd.args[1];
           const looksLikeHost = /\w+\.[A-Za-z]{2,}|^\d+\.\d+\.\d+\.\d+$/.test(extraArg);
           if (!url.includes('.') && looksLikeHost) {
-            const answer = await question(`Detected extra argument '${extraArg}'. Use that as the URL instead of '${url}'? (y/n): `);
+            const answer = await question(
+              `Detected extra argument '${extraArg}'. Use that as the URL instead of '${url}'? (y/n): `
+            );
             if ((answer || '').trim().toLowerCase().startsWith('y')) {
               finalUrl = extraArg;
             }
@@ -53,7 +58,9 @@ export function registerAddCommand(program) {
           try {
             new URL(finalUrl);
           } catch (err) {
-            const answer = await question(`URL appears missing protocol/scheme (http/https). Prepend https:// to ${finalUrl}? (y/n): `);
+            const answer = await question(
+              `URL appears missing protocol/scheme (http/https). Prepend https:// to ${finalUrl}? (y/n): `
+            );
             const n = (answer || '').trim().toLowerCase();
             if (n === 'y' || n === 'yes' || n === '') {
               finalUrl = `https://${finalUrl}`;
@@ -74,7 +81,9 @@ export function registerAddCommand(program) {
             const host = u.hostname;
             const isIPv4 = /^\d+\.\d+\.\d+\.\d+$/.test(host);
             if (!(host.includes('.') || host === 'localhost' || isIPv4)) {
-              const confirm = await question(`Detected hostname '${host}' without top-level domain. Are you sure you want to add it? (y/n): `);
+              const confirm = await question(
+                `Detected hostname '${host}' without top-level domain. Are you sure you want to add it? (y/n): `
+              );
               if (!confirm || !confirm.trim().toLowerCase().startsWith('y')) {
                 console.log(chalk.yellow('Add command aborted.'));
                 rl.close();
@@ -87,7 +96,10 @@ export function registerAddCommand(program) {
             return;
           }
         } else if (options.type === 'icmp' || options.type === 'dns') {
-          const host = finalUrl.replace(/^https?:\/\//, '').replace(/\/.+$/, '').trim();
+          const host = finalUrl
+            .replace(/^https?:\/\//, '')
+            .replace(/\/.+$/, '')
+            .trim();
 
           const ipv4Regex = /^(\d{1,3}\.){3}\d{1,3}$/;
           const isIPv4Format = ipv4Regex.test(host);
@@ -103,7 +115,9 @@ export function registerAddCommand(program) {
           }
 
           if (!isValid) {
-            const answer = await question(`The host '${host}' looks suspicious. Type a valid hostname or IP (or press enter to abort): `);
+            const answer = await question(
+              `The host '${host}' looks suspicious. Type a valid hostname or IP (or press enter to abort): `
+            );
             if (!answer || !answer.trim()) {
               console.log(chalk.yellow('Add command aborted.'));
               rl.close();
@@ -112,14 +126,20 @@ export function registerAddCommand(program) {
             finalUrl = answer.trim();
           }
         } else if (options.type === 'ssl') {
-          let host = finalUrl.replace(/^https?:\/\//, '').replace(/\/.+$/, '').split(':')[0].trim();
+          let host = finalUrl
+            .replace(/^https?:\/\//, '')
+            .replace(/\/.+$/, '')
+            .split(':')[0]
+            .trim();
 
           const hostnameRegex = /^(?!-)[A-Za-z0-9-]{1,63}(?<!-)$/;
           const parts = host.split('.');
           const isValidHostname = parts.length >= 2 && parts.every(p => hostnameRegex.test(p));
 
           if (!isValidHostname) {
-            const answer = await question(`The hostname '${host}' looks invalid for SSL check. Type a valid hostname (or press enter to abort): `);
+            const answer = await question(
+              `The hostname '${host}' looks invalid for SSL check. Type a valid hostname (or press enter to abort): `
+            );
             if (!answer || !answer.trim()) {
               console.log(chalk.yellow('Add command aborted.'));
               rl.close();
@@ -130,7 +150,11 @@ export function registerAddCommand(program) {
             finalUrl = host;
           }
           if (parseInt(options.interval, 10) < 200) {
-            console.log(chalk.gray('Note: SSL checks typically don\'t need frequent intervals. Consider using -i 3600 (1 hour) or higher.'));
+            console.log(
+              chalk.gray(
+                "Note: SSL checks typically don't need frequent intervals. Consider using -i 3600 (1 hour) or higher."
+              )
+            );
           }
         }
 
@@ -146,7 +170,10 @@ export function registerAddCommand(program) {
         let name = options.name;
         if (!name) {
           try {
-            let domain = finalUrl.replace(/^https?:\/\//, '').replace(/\/.*$/, '').replace(/^www\./, '');
+            let domain = finalUrl
+              .replace(/^https?:\/\//, '')
+              .replace(/\/.*$/, '')
+              .replace(/^www\./, '');
             name = domain.slice(0, 6);
           } catch {
             name = finalUrl.slice(0, 6);

--- a/src/commands/clear.js
+++ b/src/commands/clear.js
@@ -13,7 +13,7 @@ export function registerClearCommand(program) {
       const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 
       const answer = await new Promise(resolve => {
-        rl.question('This will delete all monitors and heartbeats. Are you sure? (y/n): ', (ans) => {
+        rl.question('This will delete all monitors and heartbeats. Are you sure? (y/n): ', ans => {
           rl.close();
           resolve(ans.trim().toLowerCase());
         });

--- a/src/commands/delete.js
+++ b/src/commands/delete.js
@@ -6,7 +6,7 @@ export function registerDeleteCommand(program) {
     .command('delete <target>')
     .alias('del')
     .description('Delete a monitor by id or name')
-    .action(async (target) => {
+    .action(async target => {
       await initDB();
       const monitors = getMonitors();
       let monitor = null;
@@ -35,7 +35,7 @@ export function registerDeleteCommand(program) {
           db.prepare('DELETE FROM ssl_certificates WHERE monitor_id = ?').run(monitor.id);
         } catch (err) {
           console.log(err);
-          console.log('If you are on verison  1.2.20 below, ignore this error')
+          console.log('If you are on verison  1.2.20 below, ignore this error');
         }
 
         db.prepare('DELETE FROM monitors WHERE id = ?').run(monitor.id);

--- a/src/commands/edit.js
+++ b/src/commands/edit.js
@@ -7,6 +7,7 @@ const MonitorSchema = z.object({
   url: z.string().min(1).optional(),
   type: z.enum(['http', 'icmp', 'dns', 'ssl']).optional(),
   interval: z.number().int().min(1).positive().optional(),
+  retries: z.number().int().min(0).positive().optional(),
   name: z.string().optional(),
   webhook_url: z.string().nullable().optional(),
   group_name: z.string().nullable().optional()
@@ -19,6 +20,7 @@ export function registerEditCommand(program) {
     .option('-u, --url <url>', 'New URL')
     .option('-t, --type <type>', 'New type (http, icmp, dns, ssl)')
     .option('-i, --interval <seconds>', 'New interval in seconds')
+    .option('-r, --retries <number>', 'Check retries before notifications are send', '0')
     .option('-n, --name <name>', 'New name')
     .option('-w, --webhook <url>', 'New webhook URL')
     .option('-g, --group <group>', 'New group name (use "none" to remove from group)')
@@ -38,6 +40,7 @@ export function registerEditCommand(program) {
         if (options.url) updates.url = options.url;
         if (options.type) updates.type = options.type;
         if (options.interval) updates.interval = parseInt(options.interval, 10);
+        if (options.retries) updates.retries = parseInt(options.retries, 10);
         if (options.name) updates.name = options.name;
         if (options.webhook) updates.webhook_url = options.webhook;
         if (options.group !== undefined) {
@@ -49,7 +52,10 @@ export function registerEditCommand(program) {
           console.log(chalk.blue(`Editing monitor: ${monitor.name} (${monitor.url})`));
           console.log(chalk.gray('Press Enter to keep current value.'));
 
-          const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+          const rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout
+          });
           const question = q => new Promise(resolve => rl.question(q, ans => resolve(ans)));
 
           const newName = await question(`Name [${monitor.name}]: `);
@@ -63,6 +69,9 @@ export function registerEditCommand(program) {
 
           const newInterval = await question(`Interval [${monitor.interval}]: `);
           if (newInterval.trim()) updates.interval = parseInt(newInterval.trim(), 10);
+
+          const newRetries = await question(`Retries [${monitor.retries}]: `);
+          if (newRetries.trim()) updates.retries = parseInt(newRetries.trim(), 10);
 
           const currentWebhook = monitor.webhook_url || 'none';
           const newWebhook = await question(`Webhook URL [${currentWebhook}]: `);

--- a/src/commands/edit.js
+++ b/src/commands/edit.js
@@ -4,136 +4,138 @@ import chalk from 'chalk';
 import readline from 'readline';
 
 const MonitorSchema = z.object({
-    url: z.string().min(1).optional(),
-    type: z.enum(['http', 'icmp', 'dns', 'ssl']).optional(),
-    interval: z.number().int().min(1).positive().optional(),
-    name: z.string().optional(),
-    webhook_url: z.string().nullable().optional(),
-    group_name: z.string().nullable().optional()
+  url: z.string().min(1).optional(),
+  type: z.enum(['http', 'icmp', 'dns', 'ssl']).optional(),
+  interval: z.number().int().min(1).positive().optional(),
+  name: z.string().optional(),
+  webhook_url: z.string().nullable().optional(),
+  group_name: z.string().nullable().optional()
 });
 
 export function registerEditCommand(program) {
-    program
-        .command('edit <idOrName>')
-        .description('Edit an existing monitor')
-        .option('-u, --url <url>', 'New URL')
-        .option('-t, --type <type>', 'New type (http, icmp, dns, ssl)')
-        .option('-i, --interval <seconds>', 'New interval in seconds')
-        .option('-n, --name <name>', 'New name')
-        .option('-w, --webhook <url>', 'New webhook URL')
-        .option('-g, --group <group>', 'New group name (use "none" to remove from group)')
-        .action(async (idOrName, options) => {
-            try {
-                await initDB();
-                const monitor = getMonitorByIdOrName(idOrName);
+  program
+    .command('edit <idOrName>')
+    .description('Edit an existing monitor')
+    .option('-u, --url <url>', 'New URL')
+    .option('-t, --type <type>', 'New type (http, icmp, dns, ssl)')
+    .option('-i, --interval <seconds>', 'New interval in seconds')
+    .option('-n, --name <name>', 'New name')
+    .option('-w, --webhook <url>', 'New webhook URL')
+    .option('-g, --group <group>', 'New group name (use "none" to remove from group)')
+    .action(async (idOrName, options) => {
+      try {
+        await initDB();
+        const monitor = getMonitorByIdOrName(idOrName);
 
-                if (!monitor) {
-                    console.error(chalk.red(`Monitor '${idOrName}' not found.`));
-                    return;
-                }
+        if (!monitor) {
+          console.error(chalk.red(`Monitor '${idOrName}' not found.`));
+          return;
+        }
 
-                let updates = {};
+        let updates = {};
 
-                // If flags are provided, use them
-                if (options.url) updates.url = options.url;
-                if (options.type) updates.type = options.type;
-                if (options.interval) updates.interval = parseInt(options.interval, 10);
-                if (options.name) updates.name = options.name;
-                if (options.webhook) updates.webhook_url = options.webhook;
-                if (options.group !== undefined) {
-                    updates.group_name = options.group.toLowerCase() === 'none' ? null : options.group;
-                }
+        // If flags are provided, use them
+        if (options.url) updates.url = options.url;
+        if (options.type) updates.type = options.type;
+        if (options.interval) updates.interval = parseInt(options.interval, 10);
+        if (options.name) updates.name = options.name;
+        if (options.webhook) updates.webhook_url = options.webhook;
+        if (options.group !== undefined) {
+          updates.group_name = options.group.toLowerCase() === 'none' ? null : options.group;
+        }
 
-                // If no flags provided, go interactive
-                if (Object.keys(updates).length === 0) {
-                    console.log(chalk.blue(`Editing monitor: ${monitor.name} (${monitor.url})`));
-                    console.log(chalk.gray('Press Enter to keep current value.'));
+        // If no flags provided, go interactive
+        if (Object.keys(updates).length === 0) {
+          console.log(chalk.blue(`Editing monitor: ${monitor.name} (${monitor.url})`));
+          console.log(chalk.gray('Press Enter to keep current value.'));
 
-                    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-                    const question = (q) => new Promise(resolve => rl.question(q, ans => resolve(ans)));
+          const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+          const question = q => new Promise(resolve => rl.question(q, ans => resolve(ans)));
 
-                    const newName = await question(`Name [${monitor.name}]: `);
-                    if (newName.trim()) updates.name = newName.trim();
+          const newName = await question(`Name [${monitor.name}]: `);
+          if (newName.trim()) updates.name = newName.trim();
 
-                    const newUrl = await question(`URL [${monitor.url}]: `);
-                    if (newUrl.trim()) updates.url = newUrl.trim();
+          const newUrl = await question(`URL [${monitor.url}]: `);
+          if (newUrl.trim()) updates.url = newUrl.trim();
 
-                    const newType = await question(`Type [${monitor.type}]: `);
-                    if (newType.trim()) updates.type = newType.trim();
+          const newType = await question(`Type [${monitor.type}]: `);
+          if (newType.trim()) updates.type = newType.trim();
 
-                    const newInterval = await question(`Interval [${monitor.interval}]: `);
-                    if (newInterval.trim()) updates.interval = parseInt(newInterval.trim(), 10);
+          const newInterval = await question(`Interval [${monitor.interval}]: `);
+          if (newInterval.trim()) updates.interval = parseInt(newInterval.trim(), 10);
 
-                    const currentWebhook = monitor.webhook_url || 'none';
-                    const newWebhook = await question(`Webhook URL [${currentWebhook}]: `);
-                    if (newWebhook.trim()) {
-                        updates.webhook_url = newWebhook.trim() === 'none' ? null : newWebhook.trim();
-                    }
+          const currentWebhook = monitor.webhook_url || 'none';
+          const newWebhook = await question(`Webhook URL [${currentWebhook}]: `);
+          if (newWebhook.trim()) {
+            updates.webhook_url = newWebhook.trim() === 'none' ? null : newWebhook.trim();
+          }
 
-                    const currentGroup = monitor.group_name || 'none';
-                    const newGroup = await question(`Group [${currentGroup}]: `);
-                    if (newGroup.trim()) {
-                        updates.group_name = newGroup.trim().toLowerCase() === 'none' ? null : newGroup.trim();
-                    }
+          const currentGroup = monitor.group_name || 'none';
+          const newGroup = await question(`Group [${currentGroup}]: `);
+          if (newGroup.trim()) {
+            updates.group_name = newGroup.trim().toLowerCase() === 'none' ? null : newGroup.trim();
+          }
 
-                    rl.close();
-                }
+          rl.close();
+        }
 
-                if (Object.keys(updates).length === 0) {
-                    console.log(chalk.yellow('No changes made.'));
-                    return;
-                }
+        if (Object.keys(updates).length === 0) {
+          console.log(chalk.yellow('No changes made.'));
+          return;
+        }
 
-                // Validate updates
-                const data = MonitorSchema.parse(updates);
+        // Validate updates
+        const data = MonitorSchema.parse(updates);
 
-                // Enhanced Validation
-                const finalType = data.type || monitor.type;
-                const finalUrl = data.url || monitor.url;
+        // Enhanced Validation
+        const finalType = data.type || monitor.type;
+        const finalUrl = data.url || monitor.url;
 
-                if (finalType === 'http') {
-                    try {
-                        const u = new URL(finalUrl);
-                        if (u.protocol !== 'http:' && u.protocol !== 'https:') {
-                            console.error(chalk.red('Error: HTTP monitor requires http:// or https:// URL.'));
-                            return;
-                        }
-                    } catch (err) {
-                        console.error(chalk.red('Error: Invalid URL provided for HTTP monitor.'));
-                        return;
-                    }
-                } else if (finalType === 'icmp' || finalType === 'dns') {
-                    // Validate hostname or IP address
-                    const host = finalUrl.replace(/^https?:\/\//, '').replace(/\/.+$/, '').trim();
-
-                    const ipv4Regex = /^(\d{1,3}\.){3}\d{1,3}$/;
-                    const isIPv4Format = ipv4Regex.test(host);
-
-                    let isValid = false;
-                    if (isIPv4Format) {
-                        const octets = host.split('.').map(Number);
-                        isValid = octets.every(octet => octet >= 0 && octet <= 255);
-                    } else {
-                        const hostnameRegex = /^(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.[A-Za-z0-9-]{1,63})*$/;
-                        isValid = hostnameRegex.test(host);
-                    }
-
-                    if (!isValid) {
-                        console.error(chalk.red(`Error: Invalid hostname or IP '${finalUrl}' for ${finalType} monitor.`));
-                        return;
-                    }
-                }
-
-                updateMonitor(monitor.id, data);
-                console.log(chalk.green(`Monitor '${monitor.name}' updated successfully.`));
-
-            } catch (err) {
-                if (err instanceof z.ZodError) {
-                    console.error(chalk.red('Validation Error:'));
-                    err.errors.forEach(e => console.error(`- ${e.path.join('.')}: ${e.message}`));
-                } else {
-                    console.error(chalk.red('Error updating monitor:'), err.message);
-                }
+        if (finalType === 'http') {
+          try {
+            const u = new URL(finalUrl);
+            if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+              console.error(chalk.red('Error: HTTP monitor requires http:// or https:// URL.'));
+              return;
             }
-        });
+          } catch (err) {
+            console.error(chalk.red('Error: Invalid URL provided for HTTP monitor.'));
+            return;
+          }
+        } else if (finalType === 'icmp' || finalType === 'dns') {
+          // Validate hostname or IP address
+          const host = finalUrl
+            .replace(/^https?:\/\//, '')
+            .replace(/\/.+$/, '')
+            .trim();
+
+          const ipv4Regex = /^(\d{1,3}\.){3}\d{1,3}$/;
+          const isIPv4Format = ipv4Regex.test(host);
+
+          let isValid = false;
+          if (isIPv4Format) {
+            const octets = host.split('.').map(Number);
+            isValid = octets.every(octet => octet >= 0 && octet <= 255);
+          } else {
+            const hostnameRegex = /^(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.[A-Za-z0-9-]{1,63})*$/;
+            isValid = hostnameRegex.test(host);
+          }
+
+          if (!isValid) {
+            console.error(chalk.red(`Error: Invalid hostname or IP '${finalUrl}' for ${finalType} monitor.`));
+            return;
+          }
+        }
+
+        updateMonitor(monitor.id, data);
+        console.log(chalk.green(`Monitor '${monitor.name}' updated successfully.`));
+      } catch (err) {
+        if (err instanceof z.ZodError) {
+          console.error(chalk.red('Validation Error:'));
+          err.errors.forEach(e => console.error(`- ${e.path.join('.')}: ${e.message}`));
+        } else {
+          console.error(chalk.red('Error updating monitor:'), err.message);
+        }
+      }
+    });
 }

--- a/src/commands/group.js
+++ b/src/commands/group.js
@@ -3,11 +3,13 @@ import chalk from 'chalk';
 import readline from 'readline';
 
 export function registerGroupCommand(program) {
-    program
-        .command('group [action]')
-        .alias('grp')
-        .description('Manage monitor groups')
-        .addHelpText('after', `
+  program
+    .command('group [action]')
+    .alias('grp')
+    .description('Manage monitor groups')
+    .addHelpText(
+      'after',
+      `
 Actions:
   list              List all groups with monitor counts (default)
   rename <old> <new>  Rename a group
@@ -20,166 +22,190 @@ Examples:
   uptimekit group rename dev development
   uptimekit group delete staging
   uptimekit group delete test --with-monitors
-`)
-        .option('--with-monitors', 'When deleting a group, also delete all monitors in the group')
-        .argument('[args...]', 'Additional arguments for the action')
-        .action(async (action, args, options) => {
-            try {
-                await initDB();
-                
-                const actionName = action || 'list';
-                
-                switch (actionName.toLowerCase()) {
-                    case 'list':
-                    case 'ls':
-                        await listGroups();
-                        break;
-                    
-                    case 'rename':
-                    case 'mv':
-                        await handleRename(args, options);
-                        break;
-                    
-                    case 'delete':
-                    case 'del':
-                    case 'rm':
-                        await handleDelete(args, options);
-                        break;
-                    
-                    default:                   
-                        console.error(chalk.red(`Unknown action: ${actionName}`));
-                        console.log(chalk.gray('Available actions: list, rename, delete'));
-                        console.log(chalk.gray('Use "uptimekit group --help" for more information.'));
-                }
-            } catch (err) {
-                console.error(chalk.red('Error:'), err.message);
-            }
-        });
+`
+    )
+    .option('--with-monitors', 'When deleting a group, also delete all monitors in the group')
+    .argument('[args...]', 'Additional arguments for the action')
+    .action(async (action, args, options) => {
+      try {
+        await initDB();
+
+        const actionName = action || 'list';
+
+        switch (actionName.toLowerCase()) {
+          case 'list':
+          case 'ls':
+            await listGroups();
+            break;
+
+          case 'rename':
+          case 'mv':
+            await handleRename(args, options);
+            break;
+
+          case 'delete':
+          case 'del':
+          case 'rm':
+            await handleDelete(args, options);
+            break;
+
+          default:
+            console.error(chalk.red(`Unknown action: ${actionName}`));
+            console.log(chalk.gray('Available actions: list, rename, delete'));
+            console.log(chalk.gray('Use "uptimekit group --help" for more information.'));
+        }
+      } catch (err) {
+        console.error(chalk.red('Error:'), err.message);
+      }
+    });
 }
 
 async function listGroups() {
-    const groups = getGroups();
-    
-    if (groups.length === 0) {
-        console.log(chalk.yellow('No groups found. Add monitors with -g/--group flag to create groups.'));
-        console.log(chalk.gray('Example: uptimekit add https://example.com -t http -i 30 -n mysite -g production'));
-        return;
+  const groups = getGroups();
+
+  if (groups.length === 0) {
+    console.log(chalk.yellow('No groups found. Add monitors with -g/--group flag to create groups.'));
+    console.log(chalk.gray('Example: uptimekit add https://example.com -t http -i 30 -n mysite -g production'));
+    return;
+  }
+
+  console.log(chalk.bold.cyan('\nMonitor Groups\n'));
+
+  let totalMonitors = 0;
+
+  groups.forEach(g => {
+    const monitors = getMonitorsByGroup(g.group_name);
+    totalMonitors += g.count;
+
+    console.log(chalk.bold(`  ${g.group_name}`));
+    console.log(chalk.gray(`    ${g.count} monitor${g.count !== 1 ? 's' : ''}`));
+
+    // Show monitor names in the group
+    if (monitors.length > 0) {
+      const names = monitors
+        .slice(0, 5)
+        .map(m => m.name || m.url)
+        .join(', ');
+      const more = monitors.length > 5 ? ` (+${monitors.length - 5} more)` : '';
+      console.log(chalk.gray(`    └─ ${names}${more}`));
     }
-    
-    console.log(chalk.bold.cyan('\nMonitor Groups\n'));
-    
-    let totalMonitors = 0;
-    
-    groups.forEach(g => {
-        const monitors = getMonitorsByGroup(g.group_name);
-        totalMonitors += g.count;
-        
-        console.log(chalk.bold(`  ${g.group_name}`));
-        console.log(chalk.gray(`    ${g.count} monitor${g.count !== 1 ? 's' : ''}`));
-        
-        // Show monitor names in the group
-        if (monitors.length > 0) {
-            const names = monitors.slice(0, 5).map(m => m.name || m.url).join(', ');
-            const more = monitors.length > 5 ? ` (+${monitors.length - 5} more)` : '';
-            console.log(chalk.gray(`    └─ ${names}${more}`));
-        }
-        console.log();
-    });
-    
-    console.log(chalk.gray(`Total: ${groups.length} group${groups.length !== 1 ? 's' : ''}, ${totalMonitors} monitor${totalMonitors !== 1 ? 's' : ''}`));
-    console.log(chalk.gray('\nTip: Use "uptimekit status -g <group>" to view monitors in a specific group.'));
+    console.log();
+  });
+
+  console.log(
+    chalk.gray(
+      `Total: ${groups.length} group${groups.length !== 1 ? 's' : ''}, ${totalMonitors} monitor${totalMonitors !== 1 ? 's' : ''}`
+    )
+  );
+  console.log(chalk.gray('\nTip: Use "uptimekit status -g <group>" to view monitors in a specific group.'));
 }
 
 async function handleRename(args, options) {
-    if (args.length < 2) {
-        console.error(chalk.red('Error: rename requires two arguments: <old-name> <new-name>'));
-        console.log(chalk.gray('Example: uptimekit group rename dev development'));
-        return;
-    }
-    
-    const [oldName, newName] = args;
-    
-    if (oldName.toLowerCase() === newName.toLowerCase()) {
-        console.log(chalk.yellow('Old name and new name are the same. No changes made.'));
-        return;
-    }
+  if (args.length < 2) {
+    console.error(chalk.red('Error: rename requires two arguments: <old-name> <new-name>'));
+    console.log(chalk.gray('Example: uptimekit group rename dev development'));
+    return;
+  }
 
-    if (!newName || newName.trim() === '') {
-        console.error(chalk.red('Error: New group name cannot be empty.'));
-        return;
-    }
-    
-    // Check if old group exists
-    if (!groupExists(oldName)) {
-        console.error(chalk.red(`Error: Group '${oldName}' does not exist.`));
-        console.log(chalk.gray('Use "uptimekit group list" to see available groups.'));
-        return;
-    }
-    
-    // Check if new name already exists
-    if (groupExists(newName) && oldName.toLowerCase() !== newName.toLowerCase()) {
-        console.error(chalk.red(`Error: Group '${newName}' already exists.`));
-        return;
-    }
-    
-    const result = renameGroup(oldName, newName);
-    console.log(chalk.green(`✔ Renamed group '${oldName}' to '${newName}' (${result.changes} monitor${result.changes !== 1 ? 's' : ''} updated)`));
+  const [oldName, newName] = args;
+
+  if (oldName.toLowerCase() === newName.toLowerCase()) {
+    console.log(chalk.yellow('Old name and new name are the same. No changes made.'));
+    return;
+  }
+
+  if (!newName || newName.trim() === '') {
+    console.error(chalk.red('Error: New group name cannot be empty.'));
+    return;
+  }
+
+  // Check if old group exists
+  if (!groupExists(oldName)) {
+    console.error(chalk.red(`Error: Group '${oldName}' does not exist.`));
+    console.log(chalk.gray('Use "uptimekit group list" to see available groups.'));
+    return;
+  }
+
+  // Check if new name already exists
+  if (groupExists(newName) && oldName.toLowerCase() !== newName.toLowerCase()) {
+    console.error(chalk.red(`Error: Group '${newName}' already exists.`));
+    return;
+  }
+
+  const result = renameGroup(oldName, newName);
+  console.log(
+    chalk.green(
+      `✔ Renamed group '${oldName}' to '${newName}' (${result.changes} monitor${result.changes !== 1 ? 's' : ''} updated)`
+    )
+  );
 }
 
 async function handleDelete(args, options) {
-    if (args.length < 1) {
-        console.error(chalk.red('Error: delete requires a group name.'));
-        console.log(chalk.gray('Example: uptimekit group delete staging'));
-        return;
-    }
-    
-    const groupName = args[0];
-    const deleteMonitors = options.withMonitors || false;
-    
-    // Check if group exists
-    if (!groupExists(groupName)) {
-        console.error(chalk.red(`Error: Group '${groupName}' does not exist.`));
-        console.log(chalk.gray('Use "uptimekit group list" to see available groups.'));
-        return;
+  if (args.length < 1) {
+    console.error(chalk.red('Error: delete requires a group name.'));
+    console.log(chalk.gray('Example: uptimekit group delete staging'));
+    return;
+  }
+
+  const groupName = args[0];
+  const deleteMonitors = options.withMonitors || false;
+
+  // Check if group exists
+  if (!groupExists(groupName)) {
+    console.error(chalk.red(`Error: Group '${groupName}' does not exist.`));
+    console.log(chalk.gray('Use "uptimekit group list" to see available groups.'));
+    return;
+  }
+
+  const monitors = getMonitorsByGroup(groupName);
+
+  if (monitors.length === 0) {
+    console.log(chalk.yellow(`Group '${groupName}' has no monitors.`));
+    return;
+  }
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const question = q => new Promise(resolve => rl.question(q, ans => resolve(ans)));
+
+  if (deleteMonitors) {
+    console.log(
+      chalk.red.bold(
+        `\nWARNING: This will permanently delete ${monitors.length} monitor${monitors.length !== 1 ? 's' : ''} and their history!`
+      )
+    );
+    monitors.forEach(m => console.log(chalk.gray(`  - ${m.name || m.url}`)));
+
+    const confirm = await question(chalk.yellow(`\nType the group name '${groupName}' to confirm deletion: `));
+    rl.close();
+
+    if (confirm.trim() !== groupName) {
+      console.log(chalk.yellow('Deletion cancelled.'));
+      return;
     }
 
-    const monitors = getMonitorsByGroup(groupName);
-    
-    if (monitors.length === 0) {
-        console.log(chalk.yellow(`Group '${groupName}' has no monitors.`));
-        return;
+    const result = deleteGroup(groupName, true);
+    console.log(
+      chalk.green(`✔ Deleted group '${groupName}' and ${result.changes} monitor${result.changes !== 1 ? 's' : ''}`)
+    );
+  } else {
+    console.log(
+      chalk.yellow(
+        `\nThis will ungroup ${monitors.length} monitor${monitors.length !== 1 ? 's' : ''} from '${groupName}'.`
+      )
+    );
+    console.log(chalk.gray('(Monitors will not be deleted, just removed from the group)'));
+
+    const confirm = await question(chalk.yellow('Continue? (y/N): '));
+    rl.close();
+
+    if (!confirm.trim().toLowerCase().startsWith('y')) {
+      console.log(chalk.yellow('Operation cancelled.'));
+      return;
     }
-    
-    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-    const question = (q) => new Promise(resolve => rl.question(q, ans => resolve(ans)));
-    
-    if (deleteMonitors) {
-        console.log(chalk.red.bold(`\nWARNING: This will permanently delete ${monitors.length} monitor${monitors.length !== 1 ? 's' : ''} and their history!`));
-        monitors.forEach(m => console.log(chalk.gray(`  - ${m.name || m.url}`)));
-        
-        const confirm = await question(chalk.yellow(`\nType the group name '${groupName}' to confirm deletion: `));
-        rl.close();
-        
-        if (confirm.trim() !== groupName) {
-            console.log(chalk.yellow('Deletion cancelled.'));
-            return;
-        }
-        
-        const result = deleteGroup(groupName, true);
-        console.log(chalk.green(`✔ Deleted group '${groupName}' and ${result.changes} monitor${result.changes !== 1 ? 's' : ''}`));
-    } else {
-        console.log(chalk.yellow(`\nThis will ungroup ${monitors.length} monitor${monitors.length !== 1 ? 's' : ''} from '${groupName}'.`));
-        console.log(chalk.gray('(Monitors will not be deleted, just removed from the group)'));
-        
-        const confirm = await question(chalk.yellow('Continue? (y/N): '));
-        rl.close();
-        
-        if (!confirm.trim().toLowerCase().startsWith('y')) {
-            console.log(chalk.yellow('Operation cancelled.'));
-            return;
-        }
-        
-        const result = deleteGroup(groupName, false);
-        console.log(chalk.green(`✔ Ungrouped ${result.changes} monitor${result.changes !== 1 ? 's' : ''} from '${groupName}'`));
-    }
+
+    const result = deleteGroup(groupName, false);
+    console.log(
+      chalk.green(`✔ Ungrouped ${result.changes} monitor${result.changes !== 1 ? 's' : ''} from '${groupName}'`)
+    );
+  }
 }

--- a/src/commands/notifications.js
+++ b/src/commands/notifications.js
@@ -2,46 +2,43 @@ import chalk from 'chalk';
 import { getNotificationSettings, setNotificationSettings } from '../core/db.js';
 
 export function registerNotificationsCommand(program) {
-    const notificationsCmd = program
-        .command('notifications')
-        .alias('notif')
-        .description('Manage desktop notifications');
+  const notificationsCmd = program.command('notifications').alias('notif').description('Manage desktop notifications');
 
-    notificationsCmd
-        .command('enable')
-        .description('Enable desktop notifications')
-        .action(() => {
-            const success = setNotificationSettings(true);
-            if (success) {
-                console.log(chalk.green('✓ Desktop notifications enabled'));
-            } else {
-                console.log(chalk.red('✗ Failed to enable notifications'));
-                process.exit(1);
-            }
-        });
+  notificationsCmd
+    .command('enable')
+    .description('Enable desktop notifications')
+    .action(() => {
+      const success = setNotificationSettings(true);
+      if (success) {
+        console.log(chalk.green('✓ Desktop notifications enabled'));
+      } else {
+        console.log(chalk.red('✗ Failed to enable notifications'));
+        process.exit(1);
+      }
+    });
 
-    notificationsCmd
-        .command('disable')
-        .description('Disable desktop notifications')
-        .action(() => {
-            const success = setNotificationSettings(false);
-            if (success) {
-                console.log(chalk.yellow('✓ Desktop notifications disabled'));
-            } else {
-                console.log(chalk.red('✗ Failed to disable notifications'));
-                process.exit(1);
-            }
-        });
+  notificationsCmd
+    .command('disable')
+    .description('Disable desktop notifications')
+    .action(() => {
+      const success = setNotificationSettings(false);
+      if (success) {
+        console.log(chalk.yellow('✓ Desktop notifications disabled'));
+      } else {
+        console.log(chalk.red('✗ Failed to disable notifications'));
+        process.exit(1);
+      }
+    });
 
-    notificationsCmd
-        .command('status')
-        .description('Show notification status')
-        .action(() => {
-            const enabled = getNotificationSettings();
-            if (enabled) {
-                console.log(chalk.green('✓ Desktop notifications are enabled'));
-            } else {
-                console.log(chalk.yellow('○ Desktop notifications are disabled'));
-            }
-        });
+  notificationsCmd
+    .command('status')
+    .description('Show notification status')
+    .action(() => {
+      const enabled = getNotificationSettings();
+      if (enabled) {
+        console.log(chalk.green('✓ Desktop notifications are enabled'));
+      } else {
+        console.log(chalk.yellow('○ Desktop notifications are disabled'));
+      }
+    });
 }

--- a/src/commands/reset.js
+++ b/src/commands/reset.js
@@ -3,34 +3,34 @@ import chalk from 'chalk';
 import readline from 'readline';
 
 export function registerResetCommand(program) {
-    program
-        .command('reset')
-        .description('Delete the local SQLite database and start fresh')
-        .action(async () => {
-            const rl = readline.createInterface({
-                input: process.stdin,
-                output: process.stdout
-            });
+  program
+    .command('reset')
+    .description('Delete the local SQLite database and start fresh')
+    .action(async () => {
+      const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout
+      });
 
-            const answer = await new Promise(resolve => {
-                rl.question('This will delete all monitors and heartbeat data. Continue? (y/N): ', (ans) => {
-                    rl.close();
-                    resolve(ans.trim().toLowerCase());
-                });
-            });
-
-            if (answer !== 'y' && answer !== 'yes') {
-                console.log(chalk.yellow('Reset aborted.'));
-                process.exit(0);
-            }
-
-            try {
-                resetDB();
-                console.log(chalk.green('Database has been reset.'));
-                process.exit(0);
-            } catch (err) {
-                console.error(chalk.red('Failed to reset database:'), err.message);
-                process.exit(1);
-            }
+      const answer = await new Promise(resolve => {
+        rl.question('This will delete all monitors and heartbeat data. Continue? (y/N): ', ans => {
+          rl.close();
+          resolve(ans.trim().toLowerCase());
         });
+      });
+
+      if (answer !== 'y' && answer !== 'yes') {
+        console.log(chalk.yellow('Reset aborted.'));
+        process.exit(0);
+      }
+
+      try {
+        resetDB();
+        console.log(chalk.green('Database has been reset.'));
+        process.exit(0);
+      } catch (err) {
+        console.error(chalk.red('Failed to reset database:'), err.message);
+        process.exit(1);
+      }
+    });
 }

--- a/src/core/db.js
+++ b/src/core/db.js
@@ -60,10 +60,8 @@ export async function initDB() {
     );
   `);
 
-
   try {
     const cols = db.prepare("PRAGMA table_info('monitors')").all();
-
 
     if (!cols.some(c => c.name === 'name')) {
       db.prepare('ALTER TABLE monitors ADD COLUMN name TEXT').run();
@@ -184,7 +182,9 @@ export function addMonitor(type, url, interval, name = null, webhookUrl = null, 
       throw new Error(`Monitor with name '${name}' already exists.`);
     }
   }
-  const stmt = db.prepare('INSERT INTO monitors (type, url, interval, name, webhook_url, group_name) VALUES (?, ?, ?, ?, ?, ?)');
+  const stmt = db.prepare(
+    'INSERT INTO monitors (type, url, interval, name, webhook_url, group_name) VALUES (?, ?, ?, ?, ?, ?)'
+  );
   return stmt.run(type, url, interval, name, webhookUrl, groupName);
 }
 
@@ -206,12 +206,30 @@ export function updateMonitor(id, updates) {
   const fields = [];
   const values = [];
 
-  if (name !== undefined) { fields.push('name = ?'); values.push(name); }
-  if (url !== undefined) { fields.push('url = ?'); values.push(url); }
-  if (type !== undefined) { fields.push('type = ?'); values.push(type); }
-  if (interval !== undefined) { fields.push('interval = ?'); values.push(interval); }
-  if (webhook_url !== undefined) { fields.push('webhook_url = ?'); values.push(webhook_url); }
-  if (group_name !== undefined) { fields.push('group_name = ?'); values.push(group_name); }
+  if (name !== undefined) {
+    fields.push('name = ?');
+    values.push(name);
+  }
+  if (url !== undefined) {
+    fields.push('url = ?');
+    values.push(url);
+  }
+  if (type !== undefined) {
+    fields.push('type = ?');
+    values.push(type);
+  }
+  if (interval !== undefined) {
+    fields.push('interval = ?');
+    values.push(interval);
+  }
+  if (webhook_url !== undefined) {
+    fields.push('webhook_url = ?');
+    values.push(webhook_url);
+  }
+  if (group_name !== undefined) {
+    fields.push('group_name = ?');
+    values.push(group_name);
+  }
 
   if (fields.length === 0) return;
 
@@ -242,7 +260,9 @@ export function getMonitorByIdOrName(idOrName) {
   if (byUrl) return byUrl;
 
   const likePattern = `%${s}%`;
-  const fuzzy = db.prepare('SELECT * FROM monitors WHERE lower(name) LIKE lower(?) OR lower(url) LIKE lower(?) LIMIT 1').get(likePattern, likePattern);
+  const fuzzy = db
+    .prepare('SELECT * FROM monitors WHERE lower(name) LIKE lower(?) OR lower(url) LIKE lower(?) LIMIT 1')
+    .get(likePattern, likePattern);
   if (fuzzy) return fuzzy;
 
   const byHost = db.prepare('SELECT * FROM monitors WHERE lower(url) LIKE lower(?) LIMIT 1').get(`%${s}%`);
@@ -250,7 +270,9 @@ export function getMonitorByIdOrName(idOrName) {
 }
 
 export function getHeartbeatsForMonitor(monitorId, limit = 60) {
-  return getDB().prepare('SELECT status, timestamp, latency FROM heartbeats WHERE monitor_id = ? ORDER BY timestamp DESC LIMIT ?').all(monitorId, limit);
+  return getDB()
+    .prepare('SELECT status, timestamp, latency FROM heartbeats WHERE monitor_id = ? ORDER BY timestamp DESC LIMIT ?')
+    .all(monitorId, limit);
 }
 
 export function logHeartbeat(monitorId, status, latency) {
@@ -289,12 +311,10 @@ export function getStats() {
   const rows = db.prepare(sql).all();
 
   return rows.map(row => {
-    const uptime = row.total_checks > 0
-      ? ((row.success_checks / row.total_checks) * 100).toFixed(2)
-      : 0;
+    const uptime = row.total_checks > 0 ? ((row.success_checks / row.total_checks) * 100).toFixed(2) : 0;
 
     // Helper to parse SQLite UTC string to Date object
-    const parseDBTimestamp = (ts) => {
+    const parseDBTimestamp = ts => {
       if (!ts) return null;
       return new Date(ts.replace(' ', 'T') + 'Z');
     };
@@ -310,7 +330,6 @@ export function getStats() {
 
     // If currently down, try to calculate how long it's been down
     if (row.current_status === 'down' && row.last_down_ts) {
-
       lastDowntimeText = `Since ${formatDistanceToNow(parseDBTimestamp(row.last_down_ts), { addSuffix: true })}`;
     }
 
@@ -405,15 +424,18 @@ export function getAllSSLCertificates() {
 
 export function getGroups() {
   const db = getDB();
-  return db.prepare(`
+  return db
+    .prepare(
+      `
     SELECT group_name, COUNT(*) as count 
     FROM monitors 
     WHERE group_name IS NOT NULL AND group_name != '' 
     GROUP BY group_name 
     ORDER BY group_name
-  `).all();
+  `
+    )
+    .all();
 }
-
 
 export function groupExists(groupName) {
   const db = getDB();
@@ -428,7 +450,9 @@ export function renameGroup(oldName, newName) {
     throw new Error(`Group '${oldName}' does not exist.`);
   }
 
-  const existingNew = db.prepare('SELECT 1 FROM monitors WHERE lower(group_name) = lower(?) AND lower(group_name) != lower(?) LIMIT 1').get(newName, oldName);
+  const existingNew = db
+    .prepare('SELECT 1 FROM monitors WHERE lower(group_name) = lower(?) AND lower(group_name) != lower(?) LIMIT 1')
+    .get(newName, oldName);
   if (existingNew) {
     throw new Error(`Group '${newName}' already exists.`);
   }
@@ -445,15 +469,19 @@ export function deleteGroup(groupName, deleteMonitors = false) {
   }
 
   if (deleteMonitors) {
-    db.prepare(`
+    db.prepare(
+      `
       DELETE FROM heartbeats 
       WHERE monitor_id IN (SELECT id FROM monitors WHERE lower(group_name) = lower(?))
-    `).run(groupName);
+    `
+    ).run(groupName);
 
-    db.prepare(`
+    db.prepare(
+      `
       DELETE FROM ssl_certificates 
       WHERE monitor_id IN (SELECT id FROM monitors WHERE lower(group_name) = lower(?))
-    `).run(groupName);
+    `
+    ).run(groupName);
 
     return db.prepare('DELETE FROM monitors WHERE lower(group_name) = lower(?)').run(groupName);
   } else {

--- a/src/core/db.js
+++ b/src/core/db.js
@@ -26,6 +26,7 @@ export async function initDB() {
       url TEXT NOT NULL,
       port INTEGER,
       interval INTEGER NOT NULL,
+      retries INTEGER DEFAULT 0,
       webhook_url TEXT,
       group_name TEXT,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP
@@ -36,6 +37,7 @@ export async function initDB() {
       monitor_id INTEGER NOT NULL,
       status TEXT NOT NULL,
       latency INTEGER,
+      retries INTEGER DEFAULT 0,
       timestamp TEXT DEFAULT CURRENT_TIMESTAMP,
       FOREIGN KEY (monitor_id) REFERENCES monitors (id) ON DELETE CASCADE
     );
@@ -61,18 +63,28 @@ export async function initDB() {
   `);
 
   try {
-    const cols = db.prepare("PRAGMA table_info('monitors')").all();
+    const monitorCols = db.prepare("PRAGMA table_info('monitors')").all();
 
-    if (!cols.some(c => c.name === 'name')) {
+    if (!monitorCols.some(c => c.name === 'name')) {
       db.prepare('ALTER TABLE monitors ADD COLUMN name TEXT').run();
     }
 
-    if (!cols.some(c => c.name === 'webhook_url')) {
+    if (!monitorCols.some(c => c.name === 'webhook_url')) {
       db.prepare('ALTER TABLE monitors ADD COLUMN webhook_url TEXT').run();
     }
 
-    if (!cols.some(c => c.name === 'group_name')) {
+    if (!monitorCols.some(c => c.name === 'group_name')) {
       db.prepare('ALTER TABLE monitors ADD COLUMN group_name TEXT').run();
+    }
+
+    if (!monitorCols.some(c => c.name === 'retries')) {
+      db.prepare('ALTER TABLE monitors ADD COLUMN retries INTEGER DEFAULT 0').run();
+    }
+
+    const heartbeatCols = db.prepare("PRAGMA table_info('heartbeats')").all();
+
+    if (!heartbeatCols.some(c => c.name === 'retries')) {
+      db.prepare('ALTER TABLE heartbeats ADD COLUMN retries INTEGER').run();
     }
   } catch (err) {
     console.error('Database column migration error:', err);
@@ -133,6 +145,7 @@ export function resetDB() {
       url TEXT NOT NULL,
       port INTEGER,
       interval INTEGER NOT NULL,
+      retries INTEGER DEFAULT 0,
       webhook_url TEXT,
       group_name TEXT,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP
@@ -143,6 +156,7 @@ export function resetDB() {
       monitor_id INTEGER NOT NULL,
       status TEXT NOT NULL,
       latency INTEGER,
+      retries INTEGER DEFAULT 0,
       timestamp TEXT DEFAULT CURRENT_TIMESTAMP,
       FOREIGN KEY (monitor_id) REFERENCES monitors (id) ON DELETE CASCADE
     );
@@ -160,7 +174,7 @@ export function resetDB() {
       last_checked TEXT DEFAULT CURRENT_TIMESTAMP,
       FOREIGN KEY (monitor_id) REFERENCES monitors (id) ON DELETE CASCADE
     );
-    
+
     CREATE INDEX IF NOT EXISTS idx_heartbeats_monitor_id ON heartbeats(monitor_id);
     CREATE INDEX IF NOT EXISTS idx_heartbeats_timestamp ON heartbeats(timestamp);
     CREATE INDEX IF NOT EXISTS idx_ssl_certificates_monitor_id ON ssl_certificates(monitor_id);
@@ -168,12 +182,17 @@ export function resetDB() {
   `);
 }
 
-export function addMonitor(type, url, interval, name = null, webhookUrl = null, groupName = null) {
+export function addMonitor(type, url, interval, retries = null, name = null, webhookUrl = null, groupName = null) {
   const db = getDB();
 
   // Validate interval
   if (interval < 1 || !Number.isInteger(interval)) {
     throw new Error('Interval must be a positive integer (minimum 1 second).');
+  }
+
+  // Validate retries
+  if (retries < 0 || !Number.isInteger(retries)) {
+    throw new Error('Retries must be an integer (minimum 0).');
   }
 
   if (name) {
@@ -183,17 +202,21 @@ export function addMonitor(type, url, interval, name = null, webhookUrl = null, 
     }
   }
   const stmt = db.prepare(
-    'INSERT INTO monitors (type, url, interval, name, webhook_url, group_name) VALUES (?, ?, ?, ?, ?, ?)'
+    'INSERT INTO monitors (type, url, interval, retries, name, webhook_url, group_name) VALUES (?, ?, ?, ?, ?, ?, ?)'
   );
-  return stmt.run(type, url, interval, name, webhookUrl, groupName);
+  return stmt.run(type, url, interval, retries, name, webhookUrl, groupName);
 }
 
 export function updateMonitor(id, updates) {
   const db = getDB();
-  const { name, url, type, interval, webhook_url, group_name } = updates;
+  const { name, url, type, interval, retries, webhook_url, group_name } = updates;
 
   if (interval !== undefined && (interval < 1 || !Number.isInteger(interval))) {
     throw new Error('Interval must be a positive integer (minimum 1 second).');
+  }
+
+  if (retries !== undefined && (retries < 0 || !Number.isInteger(retries))) {
+    throw new Error('Retries must be an integer greater than or equal to 0.');
   }
 
   if (name) {
@@ -221,6 +244,10 @@ export function updateMonitor(id, updates) {
   if (interval !== undefined) {
     fields.push('interval = ?');
     values.push(interval);
+  }
+  if (retries !== undefined) {
+    fields.push('retries = ?');
+    values.push(retries);
   }
   if (webhook_url !== undefined) {
     fields.push('webhook_url = ?');
@@ -271,13 +298,15 @@ export function getMonitorByIdOrName(idOrName) {
 
 export function getHeartbeatsForMonitor(monitorId, limit = 60) {
   return getDB()
-    .prepare('SELECT status, timestamp, latency FROM heartbeats WHERE monitor_id = ? ORDER BY timestamp DESC LIMIT ?')
+    .prepare(
+      'SELECT status, retries, timestamp, latency FROM heartbeats WHERE monitor_id = ? ORDER BY timestamp DESC LIMIT ?'
+    )
     .all(monitorId, limit);
 }
 
-export function logHeartbeat(monitorId, status, latency) {
-  const stmt = getDB().prepare('INSERT INTO heartbeats (monitor_id, status, latency) VALUES (?, ?, ?)');
-  return stmt.run(monitorId, status, latency);
+export function logHeartbeat(monitorId, status, retries, latency) {
+  const stmt = getDB().prepare('INSERT INTO heartbeats (monitor_id, status, retries, latency) VALUES (?, ?, ?, ?)');
+  return stmt.run(monitorId, status, retries, latency);
 }
 
 export function getStats() {
@@ -285,12 +314,13 @@ export function getStats() {
 
   // Single optimized query to get latest status and aggregate stats for all monitors
   const sql = `
-    SELECT 
+    SELECT
       m.*,
       COUNT(h.id) as total_checks,
       SUM(CASE WHEN h.status = 'up' THEN 1 ELSE 0 END) as success_checks,
       AVG(h.latency) as avg_latency,
       (SELECT status FROM heartbeats WHERE monitor_id = m.id ORDER BY timestamp DESC LIMIT 1) as current_status,
+      (SELECT retries FROM heartbeats WHERE monitor_id = m.id ORDER BY timestamp DESC LIMIT 1) as current_retries,
       (SELECT latency FROM heartbeats WHERE monitor_id = m.id ORDER BY timestamp DESC LIMIT 1) as current_latency,
       (SELECT timestamp FROM heartbeats WHERE monitor_id = m.id ORDER BY timestamp DESC LIMIT 1) as last_check_ts,
       (SELECT timestamp FROM heartbeats WHERE monitor_id = m.id AND status = 'down' ORDER BY timestamp DESC LIMIT 1) as last_down_ts,
@@ -320,7 +350,9 @@ export function getStats() {
     };
 
     const lastCheckTime = row.last_check_ts
-      ? formatDistanceToNow(parseDBTimestamp(row.last_check_ts), { addSuffix: true })
+      ? formatDistanceToNow(parseDBTimestamp(row.last_check_ts), {
+          addSuffix: true
+        })
       : 'Never';
 
     let lastDowntimeText = 'No downtime';
@@ -354,10 +386,12 @@ export function getStats() {
       type: row.type,
       url: row.url,
       interval: row.interval,
+      retries: row.retries,
       groupName: row.group_name,
       uptime: uptime,
       lastDowntime: lastDowntimeText,
       status: row.current_status || 'unknown',
+      current_retries: row.current_retries || 0,
       latency: Math.round(row.current_latency || 0),
       lastCheck: lastCheckTime,
       ssl: sslInfo
@@ -427,10 +461,10 @@ export function getGroups() {
   return db
     .prepare(
       `
-    SELECT group_name, COUNT(*) as count 
-    FROM monitors 
-    WHERE group_name IS NOT NULL AND group_name != '' 
-    GROUP BY group_name 
+    SELECT group_name, COUNT(*) as count
+    FROM monitors
+    WHERE group_name IS NOT NULL AND group_name != ''
+    GROUP BY group_name
     ORDER BY group_name
   `
     )
@@ -471,14 +505,14 @@ export function deleteGroup(groupName, deleteMonitors = false) {
   if (deleteMonitors) {
     db.prepare(
       `
-      DELETE FROM heartbeats 
+      DELETE FROM heartbeats
       WHERE monitor_id IN (SELECT id FROM monitors WHERE lower(group_name) = lower(?))
     `
     ).run(groupName);
 
     db.prepare(
       `
-      DELETE FROM ssl_certificates 
+      DELETE FROM ssl_certificates
       WHERE monitor_id IN (SELECT id FROM monitors WHERE lower(group_name) = lower(?))
     `
     ).run(groupName);

--- a/src/core/notifier.js
+++ b/src/core/notifier.js
@@ -7,116 +7,100 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 export async function sendWebhook(webhookUrl, event, monitor) {
-    if (!webhookUrl) return;
+  if (!webhookUrl) return;
 
-    try {
-        const payload = {
-            event: event,
-            monitor: {
-                name: monitor.name,
-                url: monitor.url,
-                status: event === 'monitor_down' ? 'down' : 'up',
-                time: new Date().toISOString()
-            }
-        };
+  try {
+    const payload = {
+      event: event,
+      monitor: {
+        name: monitor.name,
+        url: monitor.url,
+        status: event === 'monitor_down' ? 'down' : 'up',
+        time: new Date().toISOString()
+      }
+    };
 
-        await axios.post(webhookUrl, payload);
-    } catch (error) {
-        console.error(`Failed to send webhook to ${webhookUrl}:`, error.message);
-    }
+    await axios.post(webhookUrl, payload);
+  } catch (error) {
+    console.error(`Failed to send webhook to ${webhookUrl}:`, error.message);
+  }
 }
 
 export function sendNotification(title, message, options = {}) {
-    try {
-        const iconPath = path.join(__dirname, '../assets/icon.png');
+  try {
+    const iconPath = path.join(__dirname, '../assets/icon.png');
 
-        notifier.notify({
-            title: title,
-            message: message,
-            icon: iconPath,
-            contentImage: iconPath,
-            appID: 'Uptime Kit',
-            sound: options.sound !== false,
-            wait: false,
-            ...options
-        });
-    } catch (error) {
-        console.error('Failed to send notification:', error.message);
-    }
+    notifier.notify({
+      title: title,
+      message: message,
+      icon: iconPath,
+      contentImage: iconPath,
+      appID: 'Uptime Kit',
+      sound: options.sound !== false,
+      wait: false,
+      ...options
+    });
+  } catch (error) {
+    console.error('Failed to send notification:', error.message);
+  }
 }
 
 export function notifyMonitorDown(monitor) {
-    const displayName = monitor.name || monitor.url;
-    sendNotification(
-        '❌ Monitor Down',
-        `${displayName} is not responding`,
-        { sound: true }
-    );
+  const displayName = monitor.name || monitor.url;
+  sendNotification('❌ Monitor Down', `${displayName} is not responding`, { sound: true });
 
-    if (monitor.webhook_url) {
-        sendWebhook(monitor.webhook_url, 'monitor_down', monitor);
-    }
+  if (monitor.webhook_url) {
+    sendWebhook(monitor.webhook_url, 'monitor_down', monitor);
+  }
 }
 
 export function notifyMonitorUp(monitor) {
-    const displayName = monitor.name || monitor.url;
-    sendNotification(
-        '✅ Monitor Back Up',
-        `${displayName} is now responding`,
-        { sound: true }
-    );
+  const displayName = monitor.name || monitor.url;
+  sendNotification('✅ Monitor Back Up', `${displayName} is now responding`, { sound: true });
 
-    if (monitor.webhook_url) {
-        sendWebhook(monitor.webhook_url, 'monitor_up', monitor);
-    }
+  if (monitor.webhook_url) {
+    sendWebhook(monitor.webhook_url, 'monitor_up', monitor);
+  }
 }
 
 export function notifySSLExpiring(monitor, daysRemaining) {
-    const displayName = monitor.name || monitor.url;
-    let title, message;
-    
-    if (daysRemaining <= 7) {
-        title = '🚨 SSL Certificate Critical';
-        message = `${displayName} certificate expires in ${daysRemaining} days!`;
-    } else if (daysRemaining <= 14) {
-        title = '⚠️ SSL Certificate Warning';
-        message = `${displayName} certificate expires in ${daysRemaining} days`;
-    } else {
-        return;
-    }
-    
-    sendNotification(title, message, { sound: true });
+  const displayName = monitor.name || monitor.url;
+  let title, message;
 
-    if (monitor.webhook_url) {
-        sendWebhook(monitor.webhook_url, 'ssl_expiring', {
-            ...monitor,
-            daysRemaining
-        });
-    }
+  if (daysRemaining <= 7) {
+    title = '🚨 SSL Certificate Critical';
+    message = `${displayName} certificate expires in ${daysRemaining} days!`;
+  } else if (daysRemaining <= 14) {
+    title = '⚠️ SSL Certificate Warning';
+    message = `${displayName} certificate expires in ${daysRemaining} days`;
+  } else {
+    return;
+  }
+
+  sendNotification(title, message, { sound: true });
+
+  if (monitor.webhook_url) {
+    sendWebhook(monitor.webhook_url, 'ssl_expiring', {
+      ...monitor,
+      daysRemaining
+    });
+  }
 }
 
 export function notifySSLExpired(monitor) {
-    const displayName = monitor.name || monitor.url;
-    sendNotification(
-        '❌ SSL Certificate Expired',
-        `${displayName} certificate has expired!`,
-        { sound: true }
-    );
+  const displayName = monitor.name || monitor.url;
+  sendNotification('❌ SSL Certificate Expired', `${displayName} certificate has expired!`, { sound: true });
 
-    if (monitor.webhook_url) {
-        sendWebhook(monitor.webhook_url, 'ssl_expired', monitor);
-    }
+  if (monitor.webhook_url) {
+    sendWebhook(monitor.webhook_url, 'ssl_expired', monitor);
+  }
 }
 
 export function notifySSLValid(monitor) {
-    const displayName = monitor.name || monitor.url;
-    sendNotification(
-        '✅ SSL Certificate Valid',
-        `${displayName} certificate is now valid`,
-        { sound: true }
-    );
+  const displayName = monitor.name || monitor.url;
+  sendNotification('✅ SSL Certificate Valid', `${displayName} certificate is now valid`, { sound: true });
 
-    if (monitor.webhook_url) {
-        sendWebhook(monitor.webhook_url, 'ssl_valid', monitor);
-    }
+  if (monitor.webhook_url) {
+    sendWebhook(monitor.webhook_url, 'ssl_valid', monitor);
+  }
 }

--- a/src/daemon/worker.js
+++ b/src/daemon/worker.js
@@ -70,11 +70,15 @@ async function checkSSLCertificate(hostname, port = 443) {
 async function checkMonitor(monitor) {
   const start = Date.now();
   let status = 'down';
+  let retries = 0;
   let latency = 0;
 
   try {
     if (monitor.type === 'http') {
-      const res = await axios.get(monitor.url, { timeout: 5000, validateStatus: () => true });
+      const res = await axios.get(monitor.url, {
+        timeout: 5000,
+        validateStatus: () => true
+      });
       if (res.status >= 200 && res.status < 300) {
         status = 'up';
       }
@@ -125,38 +129,54 @@ async function checkMonitor(monitor) {
     console.error(`Check failed for monitor ${monitor.name || monitor.url} (${monitor.type}):`, error.message);
   }
 
-  // Get previous status to detect changes
-  const monitorData = activeMonitors.get(monitor.id);
-  const previousStatus = monitorData?.lastStatus;
+  // Get previous status and retry state
+  const monitorData = activeMonitors.get(monitor.id) || {};
+  const previousStatus = monitorData.lastStatus;
+  const previousRetries = monitorData.lastRetries || 0;
+
+  if (status === 'down') {
+    retries = previousStatus === 'down' ? previousRetries + 1 : 1;
+  } else {
+    retries = 0;
+  }
 
   // Log heartbeat
   try {
-    logHeartbeat(monitor.id, status, Math.round(latency));
+    logHeartbeat(monitor.id, status, retries, Math.round(latency));
   } catch (err) {
     console.error('Failed to log heartbeat:', err);
   }
 
-  // Send notifications on status change
-  if (previousStatus && previousStatus !== status) {
-    const notificationsEnabled = getNotificationSettings();
-    if (notificationsEnabled) {
-      if (monitor.type === 'ssl') {
-        // SSL-specific notifications
+  const notificationsEnabled = getNotificationSettings();
+
+  if (notificationsEnabled) {
+    if (monitor.type === 'ssl') {
+      // SSL-specific notifications
+      if (previousStatus && previousStatus !== status) {
         if (status === 'down') {
           notifySSLExpired(monitor);
         } else if (status === 'up') {
           notifySSLValid(monitor);
         }
-      } else {
-        // Regular monitor notifications
-        if (status === 'down') {
-          notifyMonitorDown(monitor);
-        } else if (status === 'up') {
-          notifyMonitorUp(monitor);
-        }
+      }
+    } else {
+      if (status === 'down' && previousStatus !== 'down' && (monitor.retries === 0 || retries >= monitor.retries)) {
+        notifyMonitorDown(monitor);
+      }
+
+      if (status === 'up' && previousStatus === 'down') {
+        notifyMonitorUp(monitor);
       }
     }
   }
+
+  activeMonitors.set(monitor.id, {
+    ...monitorData,
+    lastStatus: status,
+    lastRetries: retries,
+    intervalId: monitorData.intervalId,
+    monitor
+  });
 
   if (monitor.type === 'ssl' && monitor._sslCertInfo && status === 'up') {
     const notificationsEnabled = getNotificationSettings();
@@ -181,6 +201,7 @@ async function checkMonitor(monitor) {
   // Update last status
   if (monitorData) {
     monitorData.lastStatus = status;
+    monitorData.lastRetries = retries;
   }
 }
 
@@ -194,7 +215,8 @@ function startMonitorLoop(monitor, initialStatus = null) {
   activeMonitors.set(monitor.id, {
     intervalId,
     monitor,
-    lastStatus: initialStatus // Track last known status
+    lastStatus: initialStatus, // Track last known status
+    lastRetries: 0 // Track last known retries
   });
 }
 

--- a/src/daemon/worker.js
+++ b/src/daemon/worker.js
@@ -1,5 +1,11 @@
 import { initDB, getMonitors, logHeartbeat, getNotificationSettings, upsertSSLCertificate } from '../core/db.js';
-import { notifyMonitorDown, notifyMonitorUp, notifySSLExpiring, notifySSLExpired, notifySSLValid } from '../core/notifier.js';
+import {
+  notifyMonitorDown,
+  notifyMonitorUp,
+  notifySSLExpiring,
+  notifySSLExpired,
+  notifySSLValid
+} from '../core/notifier.js';
 import axios from 'axios';
 import ping from 'ping';
 import dns from 'dns/promises';
@@ -35,8 +41,8 @@ async function checkSSLCertificate(hostname, port = 443) {
         const daysRemaining = Math.floor((validTo - now) / (1000 * 60 * 60 * 24));
 
         resolve({
-          issuer: cert.issuer ? (cert.issuer.O || cert.issuer.CN || 'Unknown') : 'Unknown',
-          subject: cert.subject ? (cert.subject.CN || cert.subject.O || hostname) : hostname,
+          issuer: cert.issuer ? cert.issuer.O || cert.issuer.CN || 'Unknown' : 'Unknown',
+          subject: cert.subject ? cert.subject.CN || cert.subject.O || hostname : hostname,
           validFrom: validFrom.toISOString(),
           validTo: validTo.toISOString(),
           daysRemaining: daysRemaining,
@@ -50,7 +56,7 @@ async function checkSSLCertificate(hostname, port = 443) {
       }
     });
 
-    socket.on('error', (err) => {
+    socket.on('error', err => {
       reject(err);
     });
 
@@ -159,7 +165,6 @@ async function checkMonitor(monitor) {
       const monitorData = activeMonitors.get(monitor.id);
       const lastNotifiedThreshold = monitorData?.lastSSLNotifiedThreshold || 0;
 
-
       const thresholds = [30, 14, 7, 3, 1];
       for (const threshold of thresholds) {
         if (days <= threshold && lastNotifiedThreshold < threshold) {
@@ -212,7 +217,11 @@ async function refreshMonitors() {
         startMonitorLoop(monitor);
       } else {
         const current = activeMonitors.get(monitor.id);
-        if (current.monitor.interval !== monitor.interval || current.monitor.url !== monitor.url || current.monitor.type !== monitor.type) {
+        if (
+          current.monitor.interval !== monitor.interval ||
+          current.monitor.url !== monitor.url ||
+          current.monitor.type !== monitor.type
+        ) {
           clearInterval(current.intervalId);
           startMonitorLoop(monitor, current.lastStatus);
         }

--- a/src/index.js
+++ b/src/index.js
@@ -30,12 +30,15 @@ function isDaemonRunning() {
 const program = new Command();
 
 program.configureOutput({
-  writeErr: (str) => {
+  writeErr: str => {
     if (str.includes("option '-t, --type") && str.includes('argument missing')) {
       process.stderr.write(str + '\nAvailable types: http, icmp, dns\n');
       return;
     }
-    if (str.toLowerCase().includes("missing required argument 'url'") || str.toLowerCase().includes("missing required argument \"url\"")) {
+    if (
+      str.toLowerCase().includes("missing required argument 'url'") ||
+      str.toLowerCase().includes('missing required argument "url"')
+    ) {
       process.stderr.write(str + '\nExample: uptimekit add https://example2.com -t http -i 30 -n newsite\n');
       return;
     }
@@ -51,19 +54,32 @@ program
   .description('UptimeKit CLI - Monitor your services from the terminal')
   .version(version, '-v, --version');
 
-registerStartCommand(program);  // alias
-registerStopCommand(program);   // alias
-registerAddCommand(program);    // alias
+registerStartCommand(program); // alias
+registerStopCommand(program); // alias
+registerAddCommand(program); // alias
 registerStatusCommand(program); // alias
 registerDeleteCommand(program); // alias
-registerClearCommand(program);  // alias
+registerClearCommand(program); // alias
 registerResetCommand(program);
 registerEditCommand(program);
 registerNotificationsCommand(program);
 registerGroupCommand(program);
 
 // gotta make sure the daemon is actually running
-const allowedIfNotRunning = ['help', 'start', '-v', '--version', '-h', '--help', 'reset', 'clear', 'notifications', 'notif', 'group', 'grp'];
+const allowedIfNotRunning = [
+  'help',
+  'start',
+  '-v',
+  '--version',
+  '-h',
+  '--help',
+  'reset',
+  'clear',
+  'notifications',
+  'notif',
+  'group',
+  'grp'
+];
 const userCmd = process.argv[2];
 if (!isDaemonRunning() && userCmd && !allowedIfNotRunning.includes(userCmd)) {
   console.log('UptimeKit is not running. Please start it first using "upkit start".');

--- a/src/ui/Dashboard.js
+++ b/src/ui/Dashboard.js
@@ -8,18 +8,52 @@ const MonitorTable = ({ monitors, title, titleColor = 'white' }) => {
 
   return (
     <Box flexDirection="column" marginBottom={1}>
-      <Text bold color={titleColor} marginBottom={1}>{title}</Text>
+      <Text bold color={titleColor} marginBottom={1}>
+        {title}
+      </Text>
       <Box borderStyle="single" borderColor="gray" paddingX={1}>
-        <Box width="6%"><Text bold color="blue">#</Text></Box>
-        <Box width="20%"><Text bold color="blue">Name</Text></Box>
-        <Box width="22%"><Text bold color="blue">URL</Text></Box>
-        <Box width="8%"><Text bold color="blue">Type</Text></Box>
-        <Box width="10%"><Text bold color="blue">Status</Text></Box>
-        <Box width="10%"><Text bold color="blue">Latency</Text></Box>
-        <Box width="12%"><Text bold color="blue">Uptime (24h)</Text></Box>
-        <Box width="20%"><Text bold color="blue">Last Downtime</Text></Box>
+        <Box width="6%">
+          <Text bold color="blue">
+            #
+          </Text>
+        </Box>
+        <Box width="20%">
+          <Text bold color="blue">
+            Name
+          </Text>
+        </Box>
+        <Box width="22%">
+          <Text bold color="blue">
+            URL
+          </Text>
+        </Box>
+        <Box width="8%">
+          <Text bold color="blue">
+            Type
+          </Text>
+        </Box>
+        <Box width="10%">
+          <Text bold color="blue">
+            Status
+          </Text>
+        </Box>
+        <Box width="10%">
+          <Text bold color="blue">
+            Latency
+          </Text>
+        </Box>
+        <Box width="12%">
+          <Text bold color="blue">
+            Uptime (24h)
+          </Text>
+        </Box>
+        <Box width="20%">
+          <Text bold color="blue">
+            Last Downtime
+          </Text>
+        </Box>
       </Box>
-      {monitors.map((m) => {
+      {monitors.map(m => {
         let displayUrl = m.url;
         let displayName = m.name ? m.name : '';
         try {
@@ -38,10 +72,18 @@ const MonitorTable = ({ monitors, title, titleColor = 'white' }) => {
 
         return (
           <Box key={m.id} borderStyle="single" borderColor="gray" borderTop={false} paddingX={1}>
-            <Box width="6%"><Text>{m.id}</Text></Box>
-            <Box width="20%"><Text>{displayName}</Text></Box>
-            <Box width="22%"><Text>{displayUrl}</Text></Box>
-            <Box width="8%"><Text>{m.type}</Text></Box>
+            <Box width="6%">
+              <Text>{m.id}</Text>
+            </Box>
+            <Box width="20%">
+              <Text>{displayName}</Text>
+            </Box>
+            <Box width="22%">
+              <Text>{displayUrl}</Text>
+            </Box>
+            <Box width="8%">
+              <Text>{m.type}</Text>
+            </Box>
             <Box width="10%">
               <Text color={m.status === 'up' ? 'green' : 'red'} bold>
                 {m.status === 'up' ? '✔ UP' : '✖ DOWN'}
@@ -77,8 +119,7 @@ const Dashboard = ({ groupFilter = null }) => {
 
         const groupList = getGroups();
         setGroups(groupList);
-      } catch (error) {
-      }
+      } catch (error) {}
     };
 
     fetchData();
@@ -115,7 +156,9 @@ const Dashboard = ({ groupFilter = null }) => {
   return (
     <Box flexDirection="column" padding={1} borderStyle="round" borderColor="cyan">
       <Box marginBottom={1}>
-        <Text bold color="cyan">UptimeKit Dashboard</Text>
+        <Text bold color="cyan">
+          UptimeKit Dashboard
+        </Text>
         {groupFilter && (
           <Box marginLeft={2}>
             <Text color="yellow">Group: {groupFilter}</Text>
@@ -137,7 +180,8 @@ const Dashboard = ({ groupFilter = null }) => {
           <Text color="gray">Available groups: </Text>
           {groups.map((g, idx) => (
             <Text key={g.group_name} color="cyan">
-              {g.group_name}{idx < groups.length - 1 ? ', ' : ''}
+              {g.group_name}
+              {idx < groups.length - 1 ? ', ' : ''}
             </Text>
           ))}
           <Text color="gray"> | Use </Text>
@@ -146,38 +190,58 @@ const Dashboard = ({ groupFilter = null }) => {
         </Box>
       )}
 
-
       {sortedGroupNames.map(groupName => (
-        <MonitorTable
-          key={groupName}
-          monitors={groupedMonitors[groupName]}
-          title={groupName}
-          titleColor="cyan"
-        />
+        <MonitorTable key={groupName} monitors={groupedMonitors[groupName]} title={groupName} titleColor="cyan" />
       ))}
 
       {ungroupedMonitors.length > 0 && (
-        <MonitorTable
-          monitors={ungroupedMonitors}
-          title="Uptime Monitors"
-          titleColor="white"
-        />
+        <MonitorTable monitors={ungroupedMonitors} title="Uptime Monitors" titleColor="white" />
       )}
 
       {/* SSL Monitors Table */}
       {sslMonitors.length > 0 && (
         <Box flexDirection="column">
-          <Text bold color="magenta" marginBottom={1}>SSL Certificate Monitors</Text>
+          <Text bold color="magenta" marginBottom={1}>
+            SSL Certificate Monitors
+          </Text>
           <Box borderStyle="single" borderColor="gray" paddingX={1}>
-            <Box width="6%"><Text bold color="magenta">#</Text></Box>
-            <Box width="19%"><Text bold color="magenta">Name</Text></Box>
-            <Box width="23%"><Text bold color="magenta">Host</Text></Box>
-            <Box width="14%"><Text bold color="magenta">Status</Text></Box>
-            <Box width="12%"><Text bold color="magenta">Days Left</Text></Box>
-            <Box width="16%"><Text bold color="magenta">Expires</Text></Box>
-            <Box width="20%"><Text bold color="magenta">Issuer</Text></Box>
+            <Box width="6%">
+              <Text bold color="magenta">
+                #
+              </Text>
+            </Box>
+            <Box width="19%">
+              <Text bold color="magenta">
+                Name
+              </Text>
+            </Box>
+            <Box width="23%">
+              <Text bold color="magenta">
+                Host
+              </Text>
+            </Box>
+            <Box width="14%">
+              <Text bold color="magenta">
+                Status
+              </Text>
+            </Box>
+            <Box width="12%">
+              <Text bold color="magenta">
+                Days Left
+              </Text>
+            </Box>
+            <Box width="16%">
+              <Text bold color="magenta">
+                Expires
+              </Text>
+            </Box>
+            <Box width="20%">
+              <Text bold color="magenta">
+                Issuer
+              </Text>
+            </Box>
           </Box>
-          {sslMonitors.map((m) => {
+          {sslMonitors.map(m => {
             let displayHost = m.url;
             let displayName = m.name ? m.name : '';
             try {
@@ -205,30 +269,64 @@ const Dashboard = ({ groupFilter = null }) => {
             let statusDisplay;
             if (m.status === 'up') {
               if (days !== null && days <= 7) {
-                statusDisplay = <Text color="red" bold>⚠ EXPIRING</Text>;
+                statusDisplay = (
+                  <Text color="red" bold>
+                    ⚠ EXPIRING
+                  </Text>
+                );
               } else if (days !== null && days <= 30) {
-                statusDisplay = <Text color="yellow" bold>⚠ WARNING</Text>;
+                statusDisplay = (
+                  <Text color="yellow" bold>
+                    ⚠ WARNING
+                  </Text>
+                );
               } else {
-                statusDisplay = <Text color="green" bold>✔ VALID</Text>;
+                statusDisplay = (
+                  <Text color="green" bold>
+                    ✔ VALID
+                  </Text>
+                );
               }
             } else {
-              statusDisplay = <Text color="red" bold>✖ INVALID</Text>;
+              statusDisplay = (
+                <Text color="red" bold>
+                  ✖ INVALID
+                </Text>
+              );
             }
 
             const expiryDate = ssl.validTo ? new Date(ssl.validTo).toLocaleDateString('en-US') : 'Unknown';
-            const issuer = ssl.issuer ? (ssl.issuer.length > 18 ? ssl.issuer.slice(0, 15) + '...' : ssl.issuer) : 'Unknown';
+            const issuer = ssl.issuer
+              ? ssl.issuer.length > 18
+                ? ssl.issuer.slice(0, 15) + '...'
+                : ssl.issuer
+              : 'Unknown';
 
             return (
               <Box key={m.id} borderStyle="single" borderColor="gray" borderTop={false} paddingX={1}>
-                <Box width="6%"><Text>{m.id}</Text></Box>
-                <Box width="19%"><Text>{displayName}</Text></Box>
-                <Box width="23%"><Text>{displayHost}</Text></Box>
+                <Box width="6%">
+                  <Text>{m.id}</Text>
+                </Box>
+                <Box width="19%">
+                  <Text>{displayName}</Text>
+                </Box>
+                <Box width="23%">
+                  <Text>{displayHost}</Text>
+                </Box>
                 <Box width="14%">{statusDisplay}</Box>
                 <Box width="12%">
-                  <Text color={daysColor} bold>{days !== null && days !== undefined ? `${days} days` : 'N/A'}</Text>
+                  <Text color={daysColor} bold>
+                    {days !== null && days !== undefined ? `${days} days` : 'N/A'}
+                  </Text>
                 </Box>
-                <Box width="16%"><Text color="gray">{expiryDate}</Text></Box>
-                <Box width="20%"><Text color="gray" dimColor>{issuer}</Text></Box>
+                <Box width="16%">
+                  <Text color="gray">{expiryDate}</Text>
+                </Box>
+                <Box width="20%">
+                  <Text color="gray" dimColor>
+                    {issuer}
+                  </Text>
+                </Box>
               </Box>
             );
           })}
@@ -237,7 +335,9 @@ const Dashboard = ({ groupFilter = null }) => {
 
       {monitors.length === 0 && (
         <Box marginTop={1} paddingX={1}>
-          <Text italic color="yellow">No monitors found. Run `uptimekit add` to add one.</Text>
+          <Text italic color="yellow">
+            No monitors found. Run `uptimekit add` to add one.
+          </Text>
         </Box>
       )}
     </Box>

--- a/src/ui/Dashboard.js
+++ b/src/ui/Dashboard.js
@@ -42,6 +42,11 @@ const MonitorTable = ({ monitors, title, titleColor = 'white' }) => {
             Latency
           </Text>
         </Box>
+        <Box width="10%">
+          <Text bold color="blue">
+            Retries
+          </Text>
+        </Box>
         <Box width="12%">
           <Text bold color="blue">
             Uptime (24h)
@@ -91,6 +96,9 @@ const MonitorTable = ({ monitors, title, titleColor = 'white' }) => {
             </Box>
             <Box width="10%">
               <Text color={m.latency > 500 ? 'yellow' : 'green'}>{m.latency}ms</Text>
+            </Box>
+            <Box width="10%">
+              <Text color={m.current_retries > 1 ? 'yellow' : 'green'}>{m.current_retries}</Text>
             </Box>
             <Box width="12%">
               <Text color={parseFloat(m.uptime) > 99 ? 'green' : 'yellow'}>{m.uptime}%</Text>

--- a/src/ui/MonitorDetail.js
+++ b/src/ui/MonitorDetail.js
@@ -2,323 +2,401 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { Box, Text, useInput, useApp } from 'ink';
 import { initDB, getMonitorByIdOrName, getHeartbeatsForMonitor, getSSLCertificate } from '../core/db.js';
 
-const StatBox = ({ label, value, color = "white" }) => (
-    <Box flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1} flexGrow={1} marginRight={1}>
-        <Text color="gray" dimColor>{label}</Text>
-        <Text bold color={color}>{value}</Text>
-    </Box>
+const StatBox = ({ label, value, color = 'white' }) => (
+  <Box flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1} flexGrow={1} marginRight={1}>
+    <Text color="gray" dimColor>
+      {label}
+    </Text>
+    <Text bold color={color}>
+      {value}
+    </Text>
+  </Box>
 );
 
 const bars = [' ', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
 function renderSparkline(values, width = 60) {
-    if (!values || values.length === 0) return ''.padEnd(width, ' ');
+  if (!values || values.length === 0) return ''.padEnd(width, ' ');
 
-    // fit values to width
-    const v = values.slice(-width);
-    const max = Math.max(...v);
-    const min = Math.min(...v);
-    const range = max - min || 1;
+  // fit values to width
+  const v = values.slice(-width);
+  const max = Math.max(...v);
+  const min = Math.min(...v);
+  const range = max - min || 1;
 
-    return v.map(num => {
-        const p = Math.floor(((num - min) / range) * (bars.length - 1));
-        return bars[p] || bars[0];
-    }).join('');
+  return v
+    .map(num => {
+      const p = Math.floor(((num - min) / range) * (bars.length - 1));
+      return bars[p] || bars[0];
+    })
+    .join('');
 }
 
 export default function MonitorDetail({ idOrName }) {
-    const [monitor, setMonitor] = useState(null);
-    const [heartbeats, setHeartbeats] = useState([]);
-    const [sslCert, setSSLCert] = useState(null);
-    const [notFound, setNotFound] = useState(false);
-    const { exit } = useApp();
+  const [monitor, setMonitor] = useState(null);
+  const [heartbeats, setHeartbeats] = useState([]);
+  const [sslCert, setSSLCert] = useState(null);
+  const [notFound, setNotFound] = useState(false);
+  const { exit } = useApp();
 
-    useEffect(() => {
-        let mounted = true;
+  useEffect(() => {
+    let mounted = true;
 
-        const fetchData = async () => {
-            try {
-                await initDB();
+    const fetchData = async () => {
+      try {
+        await initDB();
 
-                const m = getMonitorByIdOrName(idOrName);
+        const m = getMonitorByIdOrName(idOrName);
 
-                if (!m) {
-                    if (mounted) setNotFound(true);
-                    setTimeout(() => { if (mounted) exit(); }, 2000);
-                    return;
-                }
-
-                if (mounted) {
-                    setMonitor(prev => {
-                        if (!prev) return m;
-                        return prev.id === m.id ? prev : m;
-                    });
-
-                    const hb = getHeartbeatsForMonitor(m.id, 60);
-
-                    setHeartbeats(prev => {
-                        if (prev.length === 0 && hb.length === 0) return prev;
-                        if (prev.length !== hb.length) return hb;
-
-                        const lastPrev = prev[0];
-                        const lastNew = hb[0];
-
-                        if (!lastPrev || !lastNew) return hb;
-                        if (lastPrev.timestamp !== lastNew.timestamp) return hb;
-
-                        return prev;
-                    });
-
-                    if (m.type === 'ssl') {
-                        const cert = getSSLCertificate(m.id);
-                        setSSLCert(cert);
-                    }
-                }
-            } catch (e) {
-                // ignore
-            }
-        };
-
-        fetchData();
-        const interval = setInterval(fetchData, 1000);
-
-        return () => {
-            mounted = false;
-            clearInterval(interval);
-        };
-    }, [idOrName, exit]);
-
-    useInput((input, key) => {
-        if (input === 'q' || key.escape) exit();
-    });
-
-    const stats = useMemo(() => {
-        const latencies = heartbeats
-            .filter(h => typeof h.latency === 'number')
-            .map(h => h.latency);
-
-        const total = heartbeats.length;
-        const up = heartbeats.filter(h => h.status === 'up').length;
-
-        const sorted = [...latencies].sort((a, b) => a - b);
-        const p95Index = Math.floor(sorted.length * 0.95);
-
-        return {
-            latencies,
-            currentStatus: heartbeats[0]?.status || 'unknown',
-            min: latencies.length ? Math.min(...latencies) : 0,
-            max: latencies.length ? Math.max(...latencies) : 0,
-            avg: latencies.length ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : 0,
-            p95: sorted[p95Index] || 0,
-            uptime: total ? ((up / total) * 100).toFixed(2) : '0.00'
-        };
-    }, [heartbeats]);
-
-    if (!monitor) {
-        return (
-            <Box padding={1} borderStyle="round" borderColor="red">
-                <Text>{notFound ? `❌ Monitor "${idOrName}" not found.` : '⏳ Loading data...'}</Text>
-            </Box>
-        );
-    }
-
-    const isSSL = monitor.type === 'ssl';
-    const isUp = stats.currentStatus === 'up' || stats.currentStatus === 200;
-    let statusColor = isUp ? "green" : "red";
-    let statusText = isUp ? "  ONLINE  " : "  OFFLINE  ";
-    
-    if (isSSL && sslCert) {
-        const days = sslCert.days_remaining;
-        if (isUp) {
-            if (days <= 7) {
-                statusColor = "red";
-                statusText = " EXPIRING ";
-            } else if (days <= 30) {
-                statusColor = "yellow";
-                statusText = " WARNING  ";
-            } else {
-                statusColor = "green";
-                statusText = "  VALID   ";
-            }
-        } else {
-            statusColor = "red";
-            statusText = " INVALID  ";
-        }
-    }
-
-    // reverse so it reads left-to-right as old-to-new
-    const historyBar = heartbeats.slice(0, 40).reverse().map((h, i) => {
-        const up = h.status === 'up';
-        return <Text key={i} color={up ? "green" : "red"}>{up ? "■" : "■"}</Text>;
-    });
-
-    // SSL Certificate Detail View
-    if (isSSL) {
-        const cert = sslCert || {};
-        const daysRemaining = cert.days_remaining;
-        let daysColor = 'green';
-        if (daysRemaining !== null && daysRemaining !== undefined) {
-            if (daysRemaining <= 7) daysColor = 'red';
-            else if (daysRemaining <= 30) daysColor = 'yellow';
+        if (!m) {
+          if (mounted) setNotFound(true);
+          setTimeout(() => {
+            if (mounted) exit();
+          }, 2000);
+          return;
         }
 
-        const formatDate = (dateStr) => {
-            if (!dateStr) return 'Unknown';
-            try {
-                return new Date(dateStr).toLocaleDateString('en-US', {
-                    year: 'numeric',
-                    month: 'short',
-                    day: 'numeric',
-                    hour: '2-digit',
-                    minute: '2-digit'
-                });
-            } catch {
-                return dateStr;
-            }
-        };
+        if (mounted) {
+          setMonitor(prev => {
+            if (!prev) return m;
+            return prev.id === m.id ? prev : m;
+          });
 
-        return (
-            <Box flexDirection="column" padding={1} borderStyle="round" borderColor={statusColor} minHeight={20}>
-                <Box justifyContent="space-between" marginBottom={1}>
-                    <Box flexDirection="column">
-                        <Box alignItems="center">
-                            <Text bold color="white" backgroundColor={statusColor}>
-                                {statusText}
-                            </Text>
-                            <Box marginLeft={1}>
-                                <Text bold color="white" underline>{monitor.name || "SSL Monitor"}</Text>
-                            </Box>
-                        </Box>
-                        <Box marginTop={1}>
-                            <Text color="cyan">{monitor.url}</Text>
-                        </Box>
-                        <Text color="gray" dimColor>Type: SSL Certificate • Interval: {monitor.interval}s</Text>
-                        {monitor.group_name && (
-                            <Text color="gray" dimColor>Group: <Text color="magenta">{monitor.group_name}</Text></Text>
-                        )}
-                    </Box>
-                    <Box flexDirection="column" alignItems="flex-end">
-                        <Text color="gray" dimColor>ID: {monitor.id}</Text>
-                        <Text color="gray" dimColor>Press 'q' to quit</Text>
-                    </Box>
-                </Box>
+          const hb = getHeartbeatsForMonitor(m.id, 60);
 
-                <Box flexDirection="column" marginBottom={1}>
-                    <Text bold color="white">Certificate Status History (Last 40 checks)</Text>
-                    <Box borderStyle="single" borderColor="gray" paddingX={1}>
-                        {historyBar.length > 0 ? historyBar : <Text color="gray">No data yet...</Text>}
-                    </Box>
-                </Box>
+          setHeartbeats(prev => {
+            if (prev.length === 0 && hb.length === 0) return prev;
+            if (prev.length !== hb.length) return hb;
 
-                <Box flexDirection="column" marginBottom={1} borderStyle="single" borderColor="gray" padding={1}>
-                    <Text bold color="white" underline>SSL Certificate Details</Text>
-                    <Box marginTop={1} flexDirection="column">
-                        <Box>
-                            <Box width="20%"><Text color="gray">Subject:</Text></Box>
-                            <Box><Text color="cyan">{cert.subject || 'Unknown'}</Text></Box>
-                        </Box>
-                        <Box>
-                            <Box width="20%"><Text color="gray">Issuer:</Text></Box>
-                            <Box><Text>{cert.issuer || 'Unknown'}</Text></Box>
-                        </Box>
-                        <Box>
-                            <Box width="20%"><Text color="gray">Valid From:</Text></Box>
-                            <Box><Text>{formatDate(cert.valid_from)}</Text></Box>
-                        </Box>
-                        <Box>
-                            <Box width="20%"><Text color="gray">Valid To:</Text></Box>
-                            <Box><Text color={daysColor}>{formatDate(cert.valid_to)}</Text></Box>
-                        </Box>
-                        <Box>
-                            <Box width="20%"><Text color="gray">Serial Number:</Text></Box>
-                            <Box><Text dimColor>{cert.serial_number || 'Unknown'}</Text></Box>
-                        </Box>
-                        <Box>
-                            <Box width="20%"><Text color="gray">Fingerprint:</Text></Box>
-                            <Box><Text dimColor>{cert.fingerprint ? cert.fingerprint.substring(0, 40) + '...' : 'Unknown'}</Text></Box>
-                        </Box>
-                        <Box>
-                            <Box width="20%"><Text color="gray">Last Checked:</Text></Box>
-                            <Box><Text dimColor>{formatDate(cert.last_checked)}</Text></Box>
-                        </Box>
-                    </Box>
-                </Box>
+            const lastPrev = prev[0];
+            const lastNew = hb[0];
 
-                <Box flexDirection="row" justifyContent="space-between">
-                    <StatBox 
-                        label="Days Remaining" 
-                        value={daysRemaining !== null && daysRemaining !== undefined ? `${daysRemaining} days` : 'N/A'} 
-                        color={daysColor} 
-                    />
-                    <StatBox 
-                        label="Certificate Status" 
-                        value={isUp ? (daysRemaining <= 7 ? 'Expiring Soon!' : daysRemaining <= 30 ? 'Warning' : 'Valid') : 'Invalid'} 
-                        color={daysColor} 
-                    />
-                    <StatBox label="Check Interval" value={`${monitor.interval}s`} />
-                    <StatBox label="Validity Rate" value={`${stats.uptime}%`} color={parseFloat(stats.uptime) > 99 ? "green" : "yellow"} />
-                </Box>
-            </Box>
-        );
+            if (!lastPrev || !lastNew) return hb;
+            if (lastPrev.timestamp !== lastNew.timestamp) return hb;
+
+            return prev;
+          });
+
+          if (m.type === 'ssl') {
+            const cert = getSSLCertificate(m.id);
+            setSSLCert(cert);
+          }
+        }
+      } catch (e) {
+        // ignore
+      }
+    };
+
+    fetchData();
+    const interval = setInterval(fetchData, 1000);
+
+    return () => {
+      mounted = false;
+      clearInterval(interval);
+    };
+  }, [idOrName, exit]);
+
+  useInput((input, key) => {
+    if (input === 'q' || key.escape) exit();
+  });
+
+  const stats = useMemo(() => {
+    const latencies = heartbeats.filter(h => typeof h.latency === 'number').map(h => h.latency);
+
+    const total = heartbeats.length;
+    const up = heartbeats.filter(h => h.status === 'up').length;
+
+    const sorted = [...latencies].sort((a, b) => a - b);
+    const p95Index = Math.floor(sorted.length * 0.95);
+
+    return {
+      latencies,
+      currentStatus: heartbeats[0]?.status || 'unknown',
+      min: latencies.length ? Math.min(...latencies) : 0,
+      max: latencies.length ? Math.max(...latencies) : 0,
+      avg: latencies.length ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : 0,
+      p95: sorted[p95Index] || 0,
+      uptime: total ? ((up / total) * 100).toFixed(2) : '0.00'
+    };
+  }, [heartbeats]);
+
+  if (!monitor) {
+    return (
+      <Box padding={1} borderStyle="round" borderColor="red">
+        <Text>{notFound ? `❌ Monitor "${idOrName}" not found.` : '⏳ Loading data...'}</Text>
+      </Box>
+    );
+  }
+
+  const isSSL = monitor.type === 'ssl';
+  const isUp = stats.currentStatus === 'up' || stats.currentStatus === 200;
+  let statusColor = isUp ? 'green' : 'red';
+  let statusText = isUp ? '  ONLINE  ' : '  OFFLINE  ';
+
+  if (isSSL && sslCert) {
+    const days = sslCert.days_remaining;
+    if (isUp) {
+      if (days <= 7) {
+        statusColor = 'red';
+        statusText = ' EXPIRING ';
+      } else if (days <= 30) {
+        statusColor = 'yellow';
+        statusText = ' WARNING  ';
+      } else {
+        statusColor = 'green';
+        statusText = '  VALID   ';
+      }
+    } else {
+      statusColor = 'red';
+      statusText = ' INVALID  ';
     }
+  }
+
+  // reverse so it reads left-to-right as old-to-new
+  const historyBar = heartbeats
+    .slice(0, 40)
+    .reverse()
+    .map((h, i) => {
+      const up = h.status === 'up';
+      return (
+        <Text key={i} color={up ? 'green' : 'red'}>
+          {up ? '■' : '■'}
+        </Text>
+      );
+    });
+
+  // SSL Certificate Detail View
+  if (isSSL) {
+    const cert = sslCert || {};
+    const daysRemaining = cert.days_remaining;
+    let daysColor = 'green';
+    if (daysRemaining !== null && daysRemaining !== undefined) {
+      if (daysRemaining <= 7) daysColor = 'red';
+      else if (daysRemaining <= 30) daysColor = 'yellow';
+    }
+
+    const formatDate = dateStr => {
+      if (!dateStr) return 'Unknown';
+      try {
+        return new Date(dateStr).toLocaleDateString('en-US', {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit'
+        });
+      } catch {
+        return dateStr;
+      }
+    };
 
     return (
-        <Box flexDirection="column" padding={1} borderStyle="round" borderColor={statusColor} minHeight={20}>
-
-            <Box justifyContent="space-between" marginBottom={1}>
-                <Box flexDirection="column">
-                    <Box alignItems="center">
-                        <Text bold color="white" backgroundColor={statusColor}>
-                            {isUp ? "  ONLINE  " : "  OFFLINE  "}
-                        </Text>
-                        <Box marginLeft={1}>
-                            <Text bold color="white" underline>{monitor.name || "Monitor"}</Text>
-                        </Box>
-                    </Box>
-                    <Box marginTop={1}>
-                        <Text color="cyan">{monitor.url}</Text>
-                    </Box>
-                    <Text color="gray" dimColor>Type: {monitor.type} • Interval: {monitor.interval}s</Text>
-                    {monitor.group_name && (
-                        <Text color="gray" dimColor>Group: <Text color="magenta">{monitor.group_name}</Text></Text>
-                    )}
-                    {monitor.webhook_url && (
-                        <Text color="gray" dimColor>
-                            Webhook: {monitor.webhook_url.length > 50 ? monitor.webhook_url.substring(0, 47) + '...' : monitor.webhook_url}
-                        </Text>
-                    )}
-                </Box>
-                <Box flexDirection="column" alignItems="flex-end">
-                    <Text color="gray" dimColor>ID: {monitor.id}</Text>
-                    <Text color="gray" dimColor>Press 'q' to quit</Text>
-                </Box>
+      <Box flexDirection="column" padding={1} borderStyle="round" borderColor={statusColor} minHeight={20}>
+        <Box justifyContent="space-between" marginBottom={1}>
+          <Box flexDirection="column">
+            <Box alignItems="center">
+              <Text bold color="white" backgroundColor={statusColor}>
+                {statusText}
+              </Text>
+              <Box marginLeft={1}>
+                <Text bold color="white" underline>
+                  {monitor.name || 'SSL Monitor'}
+                </Text>
+              </Box>
             </Box>
-
-            <Box flexDirection="column" marginBottom={1}>
-                <Text bold color="white">Recent Checks (Last 40)</Text>
-                <Box borderStyle="single" borderColor="gray" paddingX={1}>
-                    {historyBar.length > 0 ? historyBar : <Text color="gray">No data yet...</Text>}
-                </Box>
+            <Box marginTop={1}>
+              <Text color="cyan">{monitor.url}</Text>
             </Box>
-
-            <Box flexDirection="column" marginBottom={1}>
-                <Box justifyContent="space-between">
-                    <Text bold color="white">Latency (Last 60s)</Text>
-                    <Text color="gray" dimColor>Max: {stats.max}ms</Text>
-                </Box>
-                <Box borderStyle="single" borderColor="gray" paddingX={1}>
-                    <Text color={statusColor}>
-                        {renderSparkline(stats.latencies, 80)}
-                    </Text>
-                </Box>
-            </Box>
-
-            <Box flexDirection="row" justifyContent="space-between">
-                <StatBox label="Current" value={`${stats.latencies[stats.latencies.length - 1] || 0} ms`} color={statusColor} />
-                <StatBox label="Avg Latency" value={`${stats.avg} ms`} />
-                <StatBox label="P95 Latency" value={`${stats.p95} ms`} />
-                <StatBox label="Uptime (24h)" value={`${stats.uptime}%`} color={parseFloat(stats.uptime) > 99 ? "green" : "yellow"} />
-            </Box>
-
+            <Text color="gray" dimColor>
+              Type: SSL Certificate • Interval: {monitor.interval}s
+            </Text>
+            {monitor.group_name && (
+              <Text color="gray" dimColor>
+                Group: <Text color="magenta">{monitor.group_name}</Text>
+              </Text>
+            )}
+          </Box>
+          <Box flexDirection="column" alignItems="flex-end">
+            <Text color="gray" dimColor>
+              ID: {monitor.id}
+            </Text>
+            <Text color="gray" dimColor>
+              Press 'q' to quit
+            </Text>
+          </Box>
         </Box>
+
+        <Box flexDirection="column" marginBottom={1}>
+          <Text bold color="white">
+            Certificate Status History (Last 40 checks)
+          </Text>
+          <Box borderStyle="single" borderColor="gray" paddingX={1}>
+            {historyBar.length > 0 ? historyBar : <Text color="gray">No data yet...</Text>}
+          </Box>
+        </Box>
+
+        <Box flexDirection="column" marginBottom={1} borderStyle="single" borderColor="gray" padding={1}>
+          <Text bold color="white" underline>
+            SSL Certificate Details
+          </Text>
+          <Box marginTop={1} flexDirection="column">
+            <Box>
+              <Box width="20%">
+                <Text color="gray">Subject:</Text>
+              </Box>
+              <Box>
+                <Text color="cyan">{cert.subject || 'Unknown'}</Text>
+              </Box>
+            </Box>
+            <Box>
+              <Box width="20%">
+                <Text color="gray">Issuer:</Text>
+              </Box>
+              <Box>
+                <Text>{cert.issuer || 'Unknown'}</Text>
+              </Box>
+            </Box>
+            <Box>
+              <Box width="20%">
+                <Text color="gray">Valid From:</Text>
+              </Box>
+              <Box>
+                <Text>{formatDate(cert.valid_from)}</Text>
+              </Box>
+            </Box>
+            <Box>
+              <Box width="20%">
+                <Text color="gray">Valid To:</Text>
+              </Box>
+              <Box>
+                <Text color={daysColor}>{formatDate(cert.valid_to)}</Text>
+              </Box>
+            </Box>
+            <Box>
+              <Box width="20%">
+                <Text color="gray">Serial Number:</Text>
+              </Box>
+              <Box>
+                <Text dimColor>{cert.serial_number || 'Unknown'}</Text>
+              </Box>
+            </Box>
+            <Box>
+              <Box width="20%">
+                <Text color="gray">Fingerprint:</Text>
+              </Box>
+              <Box>
+                <Text dimColor>{cert.fingerprint ? cert.fingerprint.substring(0, 40) + '...' : 'Unknown'}</Text>
+              </Box>
+            </Box>
+            <Box>
+              <Box width="20%">
+                <Text color="gray">Last Checked:</Text>
+              </Box>
+              <Box>
+                <Text dimColor>{formatDate(cert.last_checked)}</Text>
+              </Box>
+            </Box>
+          </Box>
+        </Box>
+
+        <Box flexDirection="row" justifyContent="space-between">
+          <StatBox
+            label="Days Remaining"
+            value={daysRemaining !== null && daysRemaining !== undefined ? `${daysRemaining} days` : 'N/A'}
+            color={daysColor}
+          />
+          <StatBox
+            label="Certificate Status"
+            value={
+              isUp ? (daysRemaining <= 7 ? 'Expiring Soon!' : daysRemaining <= 30 ? 'Warning' : 'Valid') : 'Invalid'
+            }
+            color={daysColor}
+          />
+          <StatBox label="Check Interval" value={`${monitor.interval}s`} />
+          <StatBox
+            label="Validity Rate"
+            value={`${stats.uptime}%`}
+            color={parseFloat(stats.uptime) > 99 ? 'green' : 'yellow'}
+          />
+        </Box>
+      </Box>
     );
+  }
+
+  return (
+    <Box flexDirection="column" padding={1} borderStyle="round" borderColor={statusColor} minHeight={20}>
+      <Box justifyContent="space-between" marginBottom={1}>
+        <Box flexDirection="column">
+          <Box alignItems="center">
+            <Text bold color="white" backgroundColor={statusColor}>
+              {isUp ? '  ONLINE  ' : '  OFFLINE  '}
+            </Text>
+            <Box marginLeft={1}>
+              <Text bold color="white" underline>
+                {monitor.name || 'Monitor'}
+              </Text>
+            </Box>
+          </Box>
+          <Box marginTop={1}>
+            <Text color="cyan">{monitor.url}</Text>
+          </Box>
+          <Text color="gray" dimColor>
+            Type: {monitor.type} • Interval: {monitor.interval}s
+          </Text>
+          {monitor.group_name && (
+            <Text color="gray" dimColor>
+              Group: <Text color="magenta">{monitor.group_name}</Text>
+            </Text>
+          )}
+          {monitor.webhook_url && (
+            <Text color="gray" dimColor>
+              Webhook:{' '}
+              {monitor.webhook_url.length > 50 ? monitor.webhook_url.substring(0, 47) + '...' : monitor.webhook_url}
+            </Text>
+          )}
+        </Box>
+        <Box flexDirection="column" alignItems="flex-end">
+          <Text color="gray" dimColor>
+            ID: {monitor.id}
+          </Text>
+          <Text color="gray" dimColor>
+            Press 'q' to quit
+          </Text>
+        </Box>
+      </Box>
+
+      <Box flexDirection="column" marginBottom={1}>
+        <Text bold color="white">
+          Recent Checks (Last 40)
+        </Text>
+        <Box borderStyle="single" borderColor="gray" paddingX={1}>
+          {historyBar.length > 0 ? historyBar : <Text color="gray">No data yet...</Text>}
+        </Box>
+      </Box>
+
+      <Box flexDirection="column" marginBottom={1}>
+        <Box justifyContent="space-between">
+          <Text bold color="white">
+            Latency (Last 60s)
+          </Text>
+          <Text color="gray" dimColor>
+            Max: {stats.max}ms
+          </Text>
+        </Box>
+        <Box borderStyle="single" borderColor="gray" paddingX={1}>
+          <Text color={statusColor}>{renderSparkline(stats.latencies, 80)}</Text>
+        </Box>
+      </Box>
+
+      <Box flexDirection="row" justifyContent="space-between">
+        <StatBox label="Current" value={`${stats.latencies[stats.latencies.length - 1] || 0} ms`} color={statusColor} />
+        <StatBox label="Avg Latency" value={`${stats.avg} ms`} />
+        <StatBox label="P95 Latency" value={`${stats.p95} ms`} />
+        <StatBox
+          label="Uptime (24h)"
+          value={`${stats.uptime}%`}
+          color={parseFloat(stats.uptime) > 99 ? 'green' : 'yellow'}
+        />
+      </Box>
+    </Box>
+  );
 }

--- a/src/ui/MonitorDetail.js
+++ b/src/ui/MonitorDetail.js
@@ -111,6 +111,7 @@ export default function MonitorDetail({ idOrName }) {
     return {
       latencies,
       currentStatus: heartbeats[0]?.status || 'unknown',
+      currentRetries: heartbeats[0]?.currentRetries || 0,
       min: latencies.length ? Math.min(...latencies) : 0,
       max: latencies.length ? Math.max(...latencies) : 0,
       avg: latencies.length ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : 0,
@@ -395,6 +396,11 @@ export default function MonitorDetail({ idOrName }) {
           label="Uptime (24h)"
           value={`${stats.uptime}%`}
           color={parseFloat(stats.uptime) > 99 ? 'green' : 'yellow'}
+        />
+        <StatBox
+          label="Retries"
+          value={`${stats.currentRetries}`}
+          color={parseInt(stats.uptime, 10) === 0 ? 'green' : 'yellow'}
         />
       </Box>
     </Box>

--- a/tests/commands/commands.test.js
+++ b/tests/commands/commands.test.js
@@ -750,6 +750,7 @@ describe('Group Command Logic', () => {
         url TEXT, 
         type TEXT,
         interval INTEGER,
+        retries INTEGER DEFAULT 0,
         group_name TEXT
       );
       CREATE TABLE heartbeats (
@@ -1019,6 +1020,7 @@ describe('Add Monitor with Group', () => {
         type TEXT NOT NULL,
         url TEXT NOT NULL,
         interval INTEGER DEFAULT 60,
+        retries INTEGER DEFAULT 0,
         name TEXT,
         webhook_url TEXT,
         group_name TEXT
@@ -1035,6 +1037,20 @@ describe('Add Monitor with Group', () => {
       'http',
       'https://dev.example.com',
       60,
+      'dev-api',
+      'dev'
+    );
+
+    const monitor = db.prepare('SELECT * FROM monitors WHERE name = ?').get('dev-api');
+    expect(monitor.group_name).toBe('dev');
+  });
+
+  it('should add monitor with group and retries', () => {
+    db.prepare('INSERT INTO monitors (type, url, interval, retries, name, group_name) VALUES (?, ?, ?, ?, ?, ?)').run(
+      'http',
+      'https://dev.example.com',
+      60,
+      3,
       'dev-api',
       'dev'
     );
@@ -1095,15 +1111,17 @@ describe('Edit Monitor Group', () => {
         type TEXT NOT NULL,
         url TEXT NOT NULL,
         interval INTEGER DEFAULT 60,
+        retries INTEGER DEFAULT 0,
         name TEXT,
         webhook_url TEXT,
         group_name TEXT
       );
     `);
-    db.prepare('INSERT INTO monitors (type, url, interval, name, group_name) VALUES (?, ?, ?, ?, ?)').run(
+    db.prepare('INSERT INTO monitors (type, url, interval, retries, name, group_name) VALUES (?, ?, ?, ?, ?, ?)').run(
       'http',
       'https://example.com',
       60,
+      3,
       'test',
       'dev'
     );

--- a/tests/commands/commands.test.js
+++ b/tests/commands/commands.test.js
@@ -56,14 +56,16 @@ jest.unstable_mockModule('../../src/core/db.js', () => {
     initDB: jest.fn().mockResolvedValue(undefined),
     getDB: jest.fn(() => testDb),
     addMonitor: jest.fn((type, url, interval, name, webhook) => {
-      const stmt = testDb.prepare('INSERT INTO monitors (type, url, interval, name, webhook_url) VALUES (?, ?, ?, ?, ?)');
+      const stmt = testDb.prepare(
+        'INSERT INTO monitors (type, url, interval, name, webhook_url) VALUES (?, ?, ?, ?, ?)'
+      );
       const result = stmt.run(type, url, interval, name, webhook || null);
       return result.lastInsertRowid;
     }),
     getMonitors: jest.fn(() => {
       return testDb.prepare('SELECT * FROM monitors').all();
     }),
-    getMonitorByIdOrName: jest.fn((idOrName) => {
+    getMonitorByIdOrName: jest.fn(idOrName => {
       const id = parseInt(idOrName, 10);
       if (!isNaN(id)) {
         return testDb.prepare('SELECT * FROM monitors WHERE id = ?').get(id);
@@ -71,7 +73,9 @@ jest.unstable_mockModule('../../src/core/db.js', () => {
       return testDb.prepare('SELECT * FROM monitors WHERE name = ?').get(idOrName);
     }),
     updateMonitor: jest.fn((id, updates) => {
-      const fields = Object.keys(updates).map(k => `${k} = ?`).join(', ');
+      const fields = Object.keys(updates)
+        .map(k => `${k} = ?`)
+        .join(', ');
       const values = Object.values(updates);
       testDb.prepare(`UPDATE monitors SET ${fields} WHERE id = ?`).run(...values, id);
     }),
@@ -84,8 +88,10 @@ jest.unstable_mockModule('../../src/core/db.js', () => {
       const row = testDb.prepare("SELECT value FROM settings WHERE key = 'notifications_enabled'").get();
       return row ? row.value === '1' : true;
     }),
-    setNotificationSettings: jest.fn((enabled) => {
-      testDb.prepare("INSERT OR REPLACE INTO settings (key, value) VALUES ('notifications_enabled', ?)").run(enabled ? '1' : '0');
+    setNotificationSettings: jest.fn(enabled => {
+      testDb
+        .prepare("INSERT OR REPLACE INTO settings (key, value) VALUES ('notifications_enabled', ?)")
+        .run(enabled ? '1' : '0');
       return true;
     })
   };
@@ -106,13 +112,13 @@ describe('Delete Command', () => {
     program = new Command();
     program.exitOverride();
     registerDeleteCommand(program);
-    
+
     // Add test monitor
-    testDb.prepare('INSERT INTO monitors (id, type, url, interval, name) VALUES (?, ?, ?, ?, ?)')
+    testDb
+      .prepare('INSERT INTO monitors (id, type, url, interval, name) VALUES (?, ?, ?, ?, ?)')
       .run(1, 'http', 'https://example.com', 60, 'example');
-    testDb.prepare('INSERT INTO heartbeats (monitor_id, status, latency) VALUES (?, ?, ?)')
-      .run(1, 'up', 100);
-    
+    testDb.prepare('INSERT INTO heartbeats (monitor_id, status, latency) VALUES (?, ?, ?)').run(1, 'up', 100);
+
     originalLog = console.log;
     originalError = console.error;
     consoleLog = [];
@@ -129,42 +135,40 @@ describe('Delete Command', () => {
 
   it('should delete monitor by id', async () => {
     await program.parseAsync(['node', 'test', 'delete', '1']);
-    
+
     const monitors = testDb.prepare('SELECT * FROM monitors').all();
     expect(monitors).toHaveLength(0);
-    
+
     const heartbeats = testDb.prepare('SELECT * FROM heartbeats').all();
     expect(heartbeats).toHaveLength(0);
   });
 
   it('should delete monitor by name', async () => {
     await program.parseAsync(['node', 'test', 'delete', 'example']);
-    
+
     const monitors = testDb.prepare('SELECT * FROM monitors').all();
     expect(monitors).toHaveLength(0);
   });
 
   it('should show error for non-existent monitor', async () => {
     await program.parseAsync(['node', 'test', 'delete', 'nonexistent']);
-    
+
     expect(consoleLog.some(log => log.includes('not found'))).toBe(true);
   });
 
   it('should support del alias', async () => {
     await program.parseAsync(['node', 'test', 'del', '1']);
-    
+
     const monitors = testDb.prepare('SELECT * FROM monitors').all();
     expect(monitors).toHaveLength(0);
   });
 
   it('should delete all heartbeats for the monitor', async () => {
-    testDb.prepare('INSERT INTO heartbeats (monitor_id, status, latency) VALUES (?, ?, ?)')
-      .run(1, 'up', 150);
-    testDb.prepare('INSERT INTO heartbeats (monitor_id, status, latency) VALUES (?, ?, ?)')
-      .run(1, 'down', 0);
-    
+    testDb.prepare('INSERT INTO heartbeats (monitor_id, status, latency) VALUES (?, ?, ?)').run(1, 'up', 150);
+    testDb.prepare('INSERT INTO heartbeats (monitor_id, status, latency) VALUES (?, ?, ?)').run(1, 'down', 0);
+
     await program.parseAsync(['node', 'test', 'delete', '1']);
-    
+
     const heartbeats = testDb.prepare('SELECT * FROM heartbeats').all();
     expect(heartbeats).toHaveLength(0);
   });
@@ -180,7 +184,7 @@ describe('Notifications Command', () => {
     program = new Command();
     program.exitOverride();
     registerNotificationsCommand(program);
-    
+
     originalLog = console.log;
     consoleLog = [];
     console.log = (...args) => consoleLog.push(args.join(' '));
@@ -193,14 +197,14 @@ describe('Notifications Command', () => {
 
   it('should enable notifications', async () => {
     await program.parseAsync(['node', 'test', 'notifications', 'enable']);
-    
+
     const row = testDb.prepare("SELECT value FROM settings WHERE key = 'notifications_enabled'").get();
     expect(row.value).toBe('1');
   });
 
   it('should disable notifications', async () => {
     await program.parseAsync(['node', 'test', 'notifications', 'disable']);
-    
+
     const row = testDb.prepare("SELECT value FROM settings WHERE key = 'notifications_enabled'").get();
     expect(row.value).toBe('0');
   });
@@ -208,20 +212,20 @@ describe('Notifications Command', () => {
   it('should show notification status when enabled', async () => {
     testDb.prepare("INSERT INTO settings (key, value) VALUES ('notifications_enabled', '1')").run();
     await program.parseAsync(['node', 'test', 'notifications', 'status']);
-    
+
     expect(consoleLog.some(log => log.includes('enabled'))).toBe(true);
   });
 
   it('should show notification status when disabled', async () => {
     testDb.prepare("INSERT INTO settings (key, value) VALUES ('notifications_enabled', '0')").run();
     await program.parseAsync(['node', 'test', 'notifications', 'status']);
-    
+
     expect(consoleLog.some(log => log.includes('disabled'))).toBe(true);
   });
 
   it('should support notif alias', async () => {
     await program.parseAsync(['node', 'test', 'notif', 'enable']);
-    
+
     const row = testDb.prepare("SELECT value FROM settings WHERE key = 'notifications_enabled'").get();
     expect(row.value).toBe('1');
   });
@@ -238,10 +242,10 @@ describe('Start/Stop Daemon Logic', () => {
 
   it('should detect existing daemon via PID file', () => {
     fs.writeFileSync(TEST_PID_FILE, process.pid.toString());
-    
+
     const pid = parseInt(fs.readFileSync(TEST_PID_FILE, 'utf-8'));
     expect(pid).toBe(process.pid);
-    
+
     let processExists = false;
     try {
       process.kill(pid, 0);
@@ -254,9 +258,9 @@ describe('Start/Stop Daemon Logic', () => {
 
   it('should detect stale PID file', () => {
     fs.writeFileSync(TEST_PID_FILE, '99999999');
-    
+
     const pid = parseInt(fs.readFileSync(TEST_PID_FILE, 'utf-8'));
-    
+
     let processExists = false;
     try {
       process.kill(pid, 0);
@@ -275,17 +279,17 @@ describe('Start/Stop Daemon Logic', () => {
   it('should create daemon directory if not exists', () => {
     const testDir = path.join(os.tmpdir(), 'uptimekit-test-' + Date.now());
     expect(fs.existsSync(testDir)).toBe(false);
-    
+
     fs.mkdirSync(testDir, { recursive: true });
     expect(fs.existsSync(testDir)).toBe(true);
-    
+
     fs.rmdirSync(testDir);
   });
 
   it('should write PID to file', () => {
     const pid = 12345;
     fs.writeFileSync(TEST_PID_FILE, pid.toString());
-    
+
     const readPid = parseInt(fs.readFileSync(TEST_PID_FILE, 'utf-8'));
     expect(readPid).toBe(pid);
   });
@@ -376,7 +380,11 @@ describe('Monitor Validation', () => {
   describe('SSL hostname validation', () => {
     it('should extract hostname from URL for SSL', () => {
       const url = 'https://example.com/path';
-      const host = url.replace(/^https?:\/\//, '').replace(/\/.+$/, '').split(':')[0].trim();
+      const host = url
+        .replace(/^https?:\/\//, '')
+        .replace(/\/.+$/, '')
+        .split(':')[0]
+        .trim();
       expect(host).toBe('example.com');
     });
 
@@ -452,20 +460,29 @@ describe('Monitor Type Schema', () => {
 describe('Name Generation', () => {
   it('should generate name from domain', () => {
     const url = 'https://example.com/path';
-    let domain = url.replace(/^https?:\/\//, '').replace(/\/.*$/, '').replace(/^www\./, '');
+    let domain = url
+      .replace(/^https?:\/\//, '')
+      .replace(/\/.*$/, '')
+      .replace(/^www\./, '');
     const name = domain.slice(0, 6);
     expect(name).toBe('exampl');
   });
 
   it('should strip www prefix', () => {
     const url = 'https://www.example.com';
-    let domain = url.replace(/^https?:\/\//, '').replace(/\/.*$/, '').replace(/^www\./, '');
+    let domain = url
+      .replace(/^https?:\/\//, '')
+      .replace(/\/.*$/, '')
+      .replace(/^www\./, '');
     expect(domain).toBe('example.com');
   });
 
   it('should handle short domain', () => {
     const url = 'https://abc.io';
-    let domain = url.replace(/^https?:\/\//, '').replace(/\/.*$/, '').replace(/^www\./, '');
+    let domain = url
+      .replace(/^https?:\/\//, '')
+      .replace(/\/.*$/, '')
+      .replace(/^www\./, '');
     const name = domain.slice(0, 6);
     expect(name).toBe('abc.io');
   });
@@ -479,14 +496,20 @@ describe('Name Generation', () => {
 
   it('should handle domain with subdomain', () => {
     const url = 'https://api.example.com';
-    let domain = url.replace(/^https?:\/\//, '').replace(/\/.*$/, '').replace(/^www\./, '');
+    let domain = url
+      .replace(/^https?:\/\//, '')
+      .replace(/\/.*$/, '')
+      .replace(/^www\./, '');
     const name = domain.slice(0, 6);
     expect(name).toBe('api.ex');
   });
 
   it('should handle IP address URL', () => {
     const url = 'http://192.168.1.1';
-    let domain = url.replace(/^https?:\/\//, '').replace(/\/.*$/, '').replace(/^www\./, '');
+    let domain = url
+      .replace(/^https?:\/\//, '')
+      .replace(/\/.*$/, '')
+      .replace(/^www\./, '');
     const name = domain.slice(0, 6);
     expect(name).toBe('192.16');
   });
@@ -512,14 +535,14 @@ describe('Clear Command Logic', () => {
   it('should clear all monitors', () => {
     db.prepare('DELETE FROM heartbeats').run();
     db.prepare('DELETE FROM monitors').run();
-    
+
     const monitors = db.prepare('SELECT * FROM monitors').all();
     expect(monitors).toHaveLength(0);
   });
 
   it('should clear all heartbeats', () => {
     db.prepare('DELETE FROM heartbeats').run();
-    
+
     const heartbeats = db.prepare('SELECT * FROM heartbeats').all();
     expect(heartbeats).toHaveLength(0);
   });
@@ -527,7 +550,7 @@ describe('Clear Command Logic', () => {
   it('should clear heartbeats before monitors (FK constraint)', () => {
     db.prepare('DELETE FROM heartbeats').run();
     db.prepare('DELETE FROM monitors').run();
-    
+
     const monitors = db.prepare('SELECT * FROM monitors').all();
     const heartbeats = db.prepare('SELECT * FROM heartbeats').all();
     expect(monitors).toHaveLength(0);
@@ -602,7 +625,7 @@ describe('Edit Command Validation', () => {
     });
 
     it('should handle string interval parsing', () => {
-      const intervals = { '120': 120, '60': 60, '3600': 3600 };
+      const intervals = { 120: 120, 60: 60, 3600: 3600 };
       Object.entries(intervals).forEach(([str, num]) => {
         expect(parseInt(str, 10)).toBe(num);
       });
@@ -640,7 +663,7 @@ describe('Reset Command Logic', () => {
     db.exec('DELETE FROM heartbeats');
     db.exec('DELETE FROM monitors');
     db.exec('DELETE FROM settings');
-    
+
     expect(db.prepare('SELECT * FROM monitors').all()).toHaveLength(0);
     expect(db.prepare('SELECT * FROM heartbeats').all()).toHaveLength(0);
     expect(db.prepare('SELECT * FROM settings').all()).toHaveLength(0);
@@ -667,9 +690,9 @@ describe('Reset Command Logic', () => {
 
 describe('Status Command Logic', () => {
   it('should determine if idOrName is provided', () => {
-    expect(!!('1')).toBe(true);
-    expect(!!('mymonitor')).toBe(true);
-    expect(!!(undefined)).toBe(false);
+    expect(!!'1').toBe(true);
+    expect(!!'mymonitor').toBe(true);
+    expect(!!undefined).toBe(false);
   });
 
   it('should handle numeric id', () => {
@@ -747,30 +770,53 @@ describe('Group Command Logic', () => {
 
   describe('getGroups', () => {
     it('should return empty array when no groups exist', () => {
-      const groups = db.prepare(`
+      const groups = db
+        .prepare(
+          `
         SELECT group_name, COUNT(*) as count 
         FROM monitors 
         WHERE group_name IS NOT NULL AND group_name != '' 
         GROUP BY group_name
-      `).all();
+      `
+        )
+        .all();
       expect(groups).toEqual([]);
     });
 
     it('should return groups with counts', () => {
-      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)')
-        .run('dev1', 'https://dev1.com', 'http', 60, 'dev');
-      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)')
-        .run('dev2', 'https://dev2.com', 'http', 60, 'dev');
-      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)')
-        .run('prod1', 'https://prod1.com', 'http', 60, 'prod');
+      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)').run(
+        'dev1',
+        'https://dev1.com',
+        'http',
+        60,
+        'dev'
+      );
+      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)').run(
+        'dev2',
+        'https://dev2.com',
+        'http',
+        60,
+        'dev'
+      );
+      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)').run(
+        'prod1',
+        'https://prod1.com',
+        'http',
+        60,
+        'prod'
+      );
 
-      const groups = db.prepare(`
+      const groups = db
+        .prepare(
+          `
         SELECT group_name, COUNT(*) as count 
         FROM monitors 
         WHERE group_name IS NOT NULL AND group_name != '' 
         GROUP BY group_name 
         ORDER BY group_name
-      `).all();
+      `
+        )
+        .all();
 
       expect(groups).toHaveLength(2);
       expect(groups[0]).toEqual({ group_name: 'dev', count: 2 });
@@ -778,17 +824,31 @@ describe('Group Command Logic', () => {
     });
 
     it('should not include ungrouped monitors in groups', () => {
-      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)')
-        .run('grouped', 'https://grouped.com', 'http', 60, 'dev');
-      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)')
-        .run('ungrouped', 'https://ungrouped.com', 'http', 60, null);
+      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)').run(
+        'grouped',
+        'https://grouped.com',
+        'http',
+        60,
+        'dev'
+      );
+      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)').run(
+        'ungrouped',
+        'https://ungrouped.com',
+        'http',
+        60,
+        null
+      );
 
-      const groups = db.prepare(`
+      const groups = db
+        .prepare(
+          `
         SELECT group_name, COUNT(*) as count 
         FROM monitors 
         WHERE group_name IS NOT NULL AND group_name != '' 
         GROUP BY group_name
-      `).all();
+      `
+        )
+        .all();
 
       expect(groups).toHaveLength(1);
       expect(groups[0].count).toBe(1);
@@ -797,16 +857,26 @@ describe('Group Command Logic', () => {
 
   describe('groupExists', () => {
     it('should return true for existing group', () => {
-      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)')
-        .run('test', 'https://test.com', 'http', 60, 'dev');
+      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)').run(
+        'test',
+        'https://test.com',
+        'http',
+        60,
+        'dev'
+      );
 
       const exists = db.prepare('SELECT 1 FROM monitors WHERE lower(group_name) = lower(?) LIMIT 1').get('dev');
       expect(!!exists).toBe(true);
     });
 
     it('should return true case-insensitively', () => {
-      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)')
-        .run('test', 'https://test.com', 'http', 60, 'dev');
+      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)').run(
+        'test',
+        'https://test.com',
+        'http',
+        60,
+        'dev'
+      );
 
       const exists = db.prepare('SELECT 1 FROM monitors WHERE lower(group_name) = lower(?) LIMIT 1').get('DEV');
       expect(!!exists).toBe(true);
@@ -820,12 +890,24 @@ describe('Group Command Logic', () => {
 
   describe('renameGroup', () => {
     it('should rename all monitors in a group', () => {
-      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)')
-        .run('dev1', 'https://dev1.com', 'http', 60, 'dev');
-      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)')
-        .run('dev2', 'https://dev2.com', 'http', 60, 'dev');
+      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)').run(
+        'dev1',
+        'https://dev1.com',
+        'http',
+        60,
+        'dev'
+      );
+      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)').run(
+        'dev2',
+        'https://dev2.com',
+        'http',
+        60,
+        'dev'
+      );
 
-      const result = db.prepare('UPDATE monitors SET group_name = ? WHERE lower(group_name) = lower(?)').run('development', 'dev');
+      const result = db
+        .prepare('UPDATE monitors SET group_name = ? WHERE lower(group_name) = lower(?)')
+        .run('development', 'dev');
       expect(result.changes).toBe(2);
 
       const monitors = db.prepare('SELECT * FROM monitors WHERE group_name = ?').all('development');
@@ -833,8 +915,13 @@ describe('Group Command Logic', () => {
     });
 
     it('should handle case change in group name', () => {
-      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)')
-        .run('test', 'https://test.com', 'http', 60, 'dev');
+      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)').run(
+        'test',
+        'https://test.com',
+        'http',
+        60,
+        'dev'
+      );
 
       db.prepare('UPDATE monitors SET group_name = ? WHERE lower(group_name) = lower(?)').run('Dev', 'dev');
 
@@ -845,8 +932,13 @@ describe('Group Command Logic', () => {
 
   describe('deleteGroup', () => {
     it('should ungroup monitors when deleteMonitors is false', () => {
-      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)')
-        .run('test', 'https://test.com', 'http', 60, 'dev');
+      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)').run(
+        'test',
+        'https://test.com',
+        'http',
+        60,
+        'dev'
+      );
 
       db.prepare('UPDATE monitors SET group_name = NULL WHERE lower(group_name) = lower(?)').run('dev');
 
@@ -855,11 +947,14 @@ describe('Group Command Logic', () => {
     });
 
     it('should delete monitors when deleteMonitors is true', () => {
-      const result = db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)')
+      const result = db
+        .prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)')
         .run('test', 'https://test.com', 'http', 60, 'dev');
       db.prepare('INSERT INTO heartbeats (monitor_id) VALUES (?)').run(result.lastInsertRowid);
 
-      db.prepare('DELETE FROM heartbeats WHERE monitor_id IN (SELECT id FROM monitors WHERE lower(group_name) = lower(?))').run('dev');
+      db.prepare(
+        'DELETE FROM heartbeats WHERE monitor_id IN (SELECT id FROM monitors WHERE lower(group_name) = lower(?))'
+      ).run('dev');
       db.prepare('DELETE FROM monitors WHERE lower(group_name) = lower(?)').run('dev');
 
       const monitors = db.prepare('SELECT * FROM monitors').all();
@@ -871,12 +966,27 @@ describe('Group Command Logic', () => {
 
   describe('getMonitorsByGroup', () => {
     beforeEach(() => {
-      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)')
-        .run('dev1', 'https://dev1.com', 'http', 60, 'dev');
-      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)')
-        .run('prod1', 'https://prod1.com', 'http', 60, 'prod');
-      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)')
-        .run('ungrouped', 'https://ungrouped.com', 'http', 60, null);
+      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)').run(
+        'dev1',
+        'https://dev1.com',
+        'http',
+        60,
+        'dev'
+      );
+      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)').run(
+        'prod1',
+        'https://prod1.com',
+        'http',
+        60,
+        'prod'
+      );
+      db.prepare('INSERT INTO monitors (name, url, type, interval, group_name) VALUES (?, ?, ?, ?, ?)').run(
+        'ungrouped',
+        'https://ungrouped.com',
+        'http',
+        60,
+        null
+      );
     });
 
     it('should return monitors in a specific group', () => {
@@ -921,28 +1031,53 @@ describe('Add Monitor with Group', () => {
   });
 
   it('should add monitor with group', () => {
-    db.prepare('INSERT INTO monitors (type, url, interval, name, group_name) VALUES (?, ?, ?, ?, ?)')
-      .run('http', 'https://dev.example.com', 60, 'dev-api', 'dev');
+    db.prepare('INSERT INTO monitors (type, url, interval, name, group_name) VALUES (?, ?, ?, ?, ?)').run(
+      'http',
+      'https://dev.example.com',
+      60,
+      'dev-api',
+      'dev'
+    );
 
     const monitor = db.prepare('SELECT * FROM monitors WHERE name = ?').get('dev-api');
     expect(monitor.group_name).toBe('dev');
   });
 
   it('should add monitor without group', () => {
-    db.prepare('INSERT INTO monitors (type, url, interval, name, group_name) VALUES (?, ?, ?, ?, ?)')
-      .run('http', 'https://example.com', 60, 'api', null);
+    db.prepare('INSERT INTO monitors (type, url, interval, name, group_name) VALUES (?, ?, ?, ?, ?)').run(
+      'http',
+      'https://example.com',
+      60,
+      'api',
+      null
+    );
 
     const monitor = db.prepare('SELECT * FROM monitors WHERE name = ?').get('api');
     expect(monitor.group_name).toBeNull();
   });
 
   it('should allow same group for multiple monitors', () => {
-    db.prepare('INSERT INTO monitors (type, url, interval, name, group_name) VALUES (?, ?, ?, ?, ?)')
-      .run('http', 'https://dev1.com', 60, 'dev1', 'dev');
-    db.prepare('INSERT INTO monitors (type, url, interval, name, group_name) VALUES (?, ?, ?, ?, ?)')
-      .run('http', 'https://dev2.com', 60, 'dev2', 'dev');
-    db.prepare('INSERT INTO monitors (type, url, interval, name, group_name) VALUES (?, ?, ?, ?, ?)')
-      .run('http', 'https://dev3.com', 60, 'dev3', 'dev');
+    db.prepare('INSERT INTO monitors (type, url, interval, name, group_name) VALUES (?, ?, ?, ?, ?)').run(
+      'http',
+      'https://dev1.com',
+      60,
+      'dev1',
+      'dev'
+    );
+    db.prepare('INSERT INTO monitors (type, url, interval, name, group_name) VALUES (?, ?, ?, ?, ?)').run(
+      'http',
+      'https://dev2.com',
+      60,
+      'dev2',
+      'dev'
+    );
+    db.prepare('INSERT INTO monitors (type, url, interval, name, group_name) VALUES (?, ?, ?, ?, ?)').run(
+      'http',
+      'https://dev3.com',
+      60,
+      'dev3',
+      'dev'
+    );
 
     const monitors = db.prepare('SELECT * FROM monitors WHERE group_name = ?').all('dev');
     expect(monitors).toHaveLength(3);
@@ -965,8 +1100,13 @@ describe('Edit Monitor Group', () => {
         group_name TEXT
       );
     `);
-    db.prepare('INSERT INTO monitors (type, url, interval, name, group_name) VALUES (?, ?, ?, ?, ?)')
-      .run('http', 'https://example.com', 60, 'test', 'dev');
+    db.prepare('INSERT INTO monitors (type, url, interval, name, group_name) VALUES (?, ?, ?, ?, ?)').run(
+      'http',
+      'https://example.com',
+      60,
+      'test',
+      'dev'
+    );
   });
 
   afterEach(() => {
@@ -990,7 +1130,7 @@ describe('Edit Monitor Group', () => {
   it('should handle "none" as removing from group', () => {
     const input = 'none';
     const groupName = input.toLowerCase() === 'none' ? null : input;
-    
+
     db.prepare('UPDATE monitors SET group_name = ? WHERE name = ?').run(groupName, 'test');
 
     const monitor = db.prepare('SELECT * FROM monitors WHERE name = ?').get('test');

--- a/tests/core/db.test.js
+++ b/tests/core/db.test.js
@@ -79,7 +79,9 @@ beforeAll(async () => {
           throw new Error(`Monitor with name '${name}' already exists.`);
         }
       }
-      const stmt = db.prepare('INSERT INTO monitors (type, url, interval, name, webhook_url, group_name) VALUES (?, ?, ?, ?, ?, ?)');
+      const stmt = db.prepare(
+        'INSERT INTO monitors (type, url, interval, name, webhook_url, group_name) VALUES (?, ?, ?, ?, ?, ?)'
+      );
       return stmt.run(type, url, interval, name, webhookUrl, groupName);
     },
 
@@ -96,11 +98,26 @@ beforeAll(async () => {
       const fields = [];
       const values = [];
 
-      if (name !== undefined) { fields.push('name = ?'); values.push(name); }
-      if (url !== undefined) { fields.push('url = ?'); values.push(url); }
-      if (type !== undefined) { fields.push('type = ?'); values.push(type); }
-      if (interval !== undefined) { fields.push('interval = ?'); values.push(interval); }
-      if (webhook_url !== undefined) { fields.push('webhook_url = ?'); values.push(webhook_url); }
+      if (name !== undefined) {
+        fields.push('name = ?');
+        values.push(name);
+      }
+      if (url !== undefined) {
+        fields.push('url = ?');
+        values.push(url);
+      }
+      if (type !== undefined) {
+        fields.push('type = ?');
+        values.push(type);
+      }
+      if (interval !== undefined) {
+        fields.push('interval = ?');
+        values.push(interval);
+      }
+      if (webhook_url !== undefined) {
+        fields.push('webhook_url = ?');
+        values.push(webhook_url);
+      }
 
       if (fields.length === 0) return;
 
@@ -113,7 +130,7 @@ beforeAll(async () => {
       return db.prepare('SELECT * FROM monitors').all();
     },
 
-    getMonitorByIdOrName: (idOrName) => {
+    getMonitorByIdOrName: idOrName => {
       const s = String(idOrName || '').trim();
       if (!s) return null;
 
@@ -129,13 +146,15 @@ beforeAll(async () => {
       if (byUrl) return byUrl;
 
       const likePattern = `%${s}%`;
-      const fuzzy = db.prepare('SELECT * FROM monitors WHERE lower(name) LIKE lower(?) OR lower(url) LIKE lower(?) LIMIT 1').get(likePattern, likePattern);
+      const fuzzy = db
+        .prepare('SELECT * FROM monitors WHERE lower(name) LIKE lower(?) OR lower(url) LIKE lower(?) LIMIT 1')
+        .get(likePattern, likePattern);
       if (fuzzy) return fuzzy;
 
       return null;
     },
 
-    deleteMonitor: (id) => {
+    deleteMonitor: id => {
       return db.prepare('DELETE FROM monitors WHERE id = ?').run(id);
     },
 
@@ -145,7 +164,11 @@ beforeAll(async () => {
     },
 
     getHeartbeatsForMonitor: (monitorId, limit = 60) => {
-      return db.prepare('SELECT status, timestamp, latency FROM heartbeats WHERE monitor_id = ? ORDER BY timestamp DESC LIMIT ?').all(monitorId, limit);
+      return db
+        .prepare(
+          'SELECT status, timestamp, latency FROM heartbeats WHERE monitor_id = ? ORDER BY timestamp DESC LIMIT ?'
+        )
+        .all(monitorId, limit);
     },
 
     getNotificationSettings: () => {
@@ -153,7 +176,7 @@ beforeAll(async () => {
       return result ? result.value === '1' : true;
     },
 
-    setNotificationSettings: (enabled) => {
+    setNotificationSettings: enabled => {
       const value = enabled ? '1' : '0';
       db.prepare("INSERT OR REPLACE INTO settings (key, value) VALUES ('notifications_enabled', ?)").run(value);
       return true;
@@ -179,7 +202,7 @@ beforeAll(async () => {
       return stmt.run(monitorId, issuer, subject, validFrom, validTo, daysRemaining, serialNumber, fingerprint);
     },
 
-    getSSLCertificate: (monitorId) => {
+    getSSLCertificate: monitorId => {
       return db.prepare('SELECT * FROM ssl_certificates WHERE monitor_id = ?').get(monitorId);
     },
 
@@ -552,7 +575,7 @@ describe('Database Module', () => {
       testFunctions.upsertSSLCertificate(monitorId, certData1);
 
       const certData2 = {
-        issuer: 'Let\'s Encrypt',
+        issuer: "Let's Encrypt",
         subject: 'github.com',
         validFrom: '2024-06-01T00:00:00Z',
         validTo: '2025-06-01T00:00:00Z',

--- a/tests/core/group.test.js
+++ b/tests/core/group.test.js
@@ -71,7 +71,9 @@ beforeAll(async () => {
           throw new Error(`Monitor with name '${name}' already exists.`);
         }
       }
-      const stmt = db.prepare('INSERT INTO monitors (type, url, interval, name, webhook_url, group_name) VALUES (?, ?, ?, ?, ?, ?)');
+      const stmt = db.prepare(
+        'INSERT INTO monitors (type, url, interval, name, webhook_url, group_name) VALUES (?, ?, ?, ?, ?, ?)'
+      );
       return stmt.run(type, url, interval, name, webhookUrl, groupName);
     },
 
@@ -88,12 +90,30 @@ beforeAll(async () => {
       const fields = [];
       const values = [];
 
-      if (name !== undefined) { fields.push('name = ?'); values.push(name); }
-      if (url !== undefined) { fields.push('url = ?'); values.push(url); }
-      if (type !== undefined) { fields.push('type = ?'); values.push(type); }
-      if (interval !== undefined) { fields.push('interval = ?'); values.push(interval); }
-      if (webhook_url !== undefined) { fields.push('webhook_url = ?'); values.push(webhook_url); }
-      if (group_name !== undefined) { fields.push('group_name = ?'); values.push(group_name); }
+      if (name !== undefined) {
+        fields.push('name = ?');
+        values.push(name);
+      }
+      if (url !== undefined) {
+        fields.push('url = ?');
+        values.push(url);
+      }
+      if (type !== undefined) {
+        fields.push('type = ?');
+        values.push(type);
+      }
+      if (interval !== undefined) {
+        fields.push('interval = ?');
+        values.push(interval);
+      }
+      if (webhook_url !== undefined) {
+        fields.push('webhook_url = ?');
+        values.push(webhook_url);
+      }
+      if (group_name !== undefined) {
+        fields.push('group_name = ?');
+        values.push(group_name);
+      }
 
       if (fields.length === 0) return;
 
@@ -106,7 +126,7 @@ beforeAll(async () => {
       return db.prepare('SELECT * FROM monitors').all();
     },
 
-    getMonitorByIdOrName: (idOrName) => {
+    getMonitorByIdOrName: idOrName => {
       const s = String(idOrName || '').trim();
       if (!s) return null;
 
@@ -121,7 +141,7 @@ beforeAll(async () => {
       return null;
     },
 
-    deleteMonitor: (id) => {
+    deleteMonitor: id => {
       db.prepare('DELETE FROM heartbeats WHERE monitor_id = ?').run(id);
       db.prepare('DELETE FROM ssl_certificates WHERE monitor_id = ?').run(id);
       return db.prepare('DELETE FROM monitors WHERE id = ?').run(id);
@@ -134,16 +154,20 @@ beforeAll(async () => {
 
     // Group management functions
     getGroups: () => {
-      return db.prepare(`
+      return db
+        .prepare(
+          `
         SELECT group_name, COUNT(*) as count 
         FROM monitors 
         WHERE group_name IS NOT NULL AND group_name != '' 
         GROUP BY group_name 
         ORDER BY group_name
-      `).all();
+      `
+        )
+        .all();
     },
 
-    groupExists: (groupName) => {
+    groupExists: groupName => {
       const result = db.prepare('SELECT 1 FROM monitors WHERE lower(group_name) = lower(?) LIMIT 1').get(groupName);
       return !!result;
     },
@@ -152,12 +176,14 @@ beforeAll(async () => {
       if (!testFunctions.groupExists(oldName)) {
         throw new Error(`Group '${oldName}' does not exist.`);
       }
-      
-      const existingNew = db.prepare('SELECT 1 FROM monitors WHERE lower(group_name) = lower(?) AND lower(group_name) != lower(?) LIMIT 1').get(newName, oldName);
+
+      const existingNew = db
+        .prepare('SELECT 1 FROM monitors WHERE lower(group_name) = lower(?) AND lower(group_name) != lower(?) LIMIT 1')
+        .get(newName, oldName);
       if (existingNew) {
         throw new Error(`Group '${newName}' already exists.`);
       }
-      
+
       const stmt = db.prepare('UPDATE monitors SET group_name = ? WHERE lower(group_name) = lower(?)');
       return stmt.run(newName, oldName);
     },
@@ -166,25 +192,29 @@ beforeAll(async () => {
       if (!testFunctions.groupExists(groupName)) {
         throw new Error(`Group '${groupName}' does not exist.`);
       }
-      
+
       if (deleteMonitors) {
-        db.prepare(`
+        db.prepare(
+          `
           DELETE FROM heartbeats 
           WHERE monitor_id IN (SELECT id FROM monitors WHERE lower(group_name) = lower(?))
-        `).run(groupName);
-        
-        db.prepare(`
+        `
+        ).run(groupName);
+
+        db.prepare(
+          `
           DELETE FROM ssl_certificates 
           WHERE monitor_id IN (SELECT id FROM monitors WHERE lower(group_name) = lower(?))
-        `).run(groupName);
-        
+        `
+        ).run(groupName);
+
         return db.prepare('DELETE FROM monitors WHERE lower(group_name) = lower(?)').run(groupName);
       } else {
         return db.prepare('UPDATE monitors SET group_name = NULL WHERE lower(group_name) = lower(?)').run(groupName);
       }
     },
 
-    getMonitorsByGroup: (groupName) => {
+    getMonitorsByGroup: groupName => {
       if (groupName === null || groupName === 'ungrouped') {
         return db.prepare("SELECT * FROM monitors WHERE group_name IS NULL OR group_name = ''").all();
       }
@@ -218,9 +248,9 @@ describe('Group Management', () => {
   describe('addMonitor with group', () => {
     it('should add a monitor with a group', () => {
       const result = testFunctions.addMonitor('http', 'https://dev.example.com', 60, 'dev-api', null, 'dev');
-      
+
       expect(result.changes).toBe(1);
-      
+
       const monitors = testFunctions.getMonitors();
       expect(monitors).toHaveLength(1);
       expect(monitors[0].group_name).toBe('dev');
@@ -228,9 +258,9 @@ describe('Group Management', () => {
 
     it('should add a monitor without a group (null)', () => {
       const result = testFunctions.addMonitor('http', 'https://example.com', 60, 'ungrouped-api', null, null);
-      
+
       expect(result.changes).toBe(1);
-      
+
       const monitors = testFunctions.getMonitors();
       expect(monitors[0].group_name).toBeNull();
     });
@@ -239,7 +269,7 @@ describe('Group Management', () => {
       testFunctions.addMonitor('http', 'https://api1.dev.com', 60, 'dev-api1', null, 'dev');
       testFunctions.addMonitor('http', 'https://api2.dev.com', 60, 'dev-api2', null, 'dev');
       testFunctions.addMonitor('http', 'https://api3.dev.com', 60, 'dev-api3', null, 'dev');
-      
+
       const monitors = testFunctions.getMonitorsByGroup('dev');
       expect(monitors).toHaveLength(3);
     });
@@ -247,10 +277,10 @@ describe('Group Management', () => {
     it('should allow same monitor name pattern in different groups', () => {
       testFunctions.addMonitor('http', 'https://dev.api.com', 60, 'dev-api', null, 'dev');
       testFunctions.addMonitor('http', 'https://prod.api.com', 60, 'prod-api', null, 'prod');
-      
+
       const devMonitors = testFunctions.getMonitorsByGroup('dev');
       const prodMonitors = testFunctions.getMonitorsByGroup('prod');
-      
+
       expect(devMonitors).toHaveLength(1);
       expect(prodMonitors).toHaveLength(1);
     });
@@ -266,14 +296,14 @@ describe('Group Management', () => {
 
     it('should update monitor group', () => {
       testFunctions.updateMonitor(monitorId, { group_name: 'prod' });
-      
+
       const monitor = testFunctions.getMonitorByIdOrName(String(monitorId));
       expect(monitor.group_name).toBe('prod');
     });
 
     it('should remove monitor from group (set to null)', () => {
       testFunctions.updateMonitor(monitorId, { group_name: null });
-      
+
       const monitor = testFunctions.getMonitorByIdOrName(String(monitorId));
       expect(monitor.group_name).toBeNull();
     });
@@ -283,7 +313,7 @@ describe('Group Management', () => {
         name: 'renamed-api',
         group_name: 'staging'
       });
-      
+
       const monitor = testFunctions.getMonitorByIdOrName(String(monitorId));
       expect(monitor.name).toBe('renamed-api');
       expect(monitor.group_name).toBe('staging');
@@ -299,7 +329,7 @@ describe('Group Management', () => {
     it('should return empty array when monitors have no groups', () => {
       testFunctions.addMonitor('http', 'https://a.com', 60, 'a', null, null);
       testFunctions.addMonitor('http', 'https://b.com', 60, 'b', null, null);
-      
+
       const groups = testFunctions.getGroups();
       expect(groups).toEqual([]);
     });
@@ -308,9 +338,9 @@ describe('Group Management', () => {
       testFunctions.addMonitor('http', 'https://dev1.com', 60, 'dev1', null, 'dev');
       testFunctions.addMonitor('http', 'https://dev2.com', 60, 'dev2', null, 'dev');
       testFunctions.addMonitor('http', 'https://prod1.com', 60, 'prod1', null, 'prod');
-      
+
       const groups = testFunctions.getGroups();
-      
+
       expect(groups).toHaveLength(2);
       expect(groups.find(g => g.group_name === 'dev').count).toBe(2);
       expect(groups.find(g => g.group_name === 'prod').count).toBe(1);
@@ -320,9 +350,9 @@ describe('Group Management', () => {
       testFunctions.addMonitor('http', 'https://z.com', 60, 'z', null, 'zebra');
       testFunctions.addMonitor('http', 'https://a.com', 60, 'a', null, 'alpha');
       testFunctions.addMonitor('http', 'https://m.com', 60, 'm', null, 'mid');
-      
+
       const groups = testFunctions.getGroups();
-      
+
       expect(groups[0].group_name).toBe('alpha');
       expect(groups[1].group_name).toBe('mid');
       expect(groups[2].group_name).toBe('zebra');
@@ -331,9 +361,9 @@ describe('Group Management', () => {
     it('should not include monitors with empty string group', () => {
       testFunctions.addMonitor('http', 'https://a.com', 60, 'a', null, '');
       testFunctions.addMonitor('http', 'https://b.com', 60, 'b', null, 'valid');
-      
+
       const groups = testFunctions.getGroups();
-      
+
       expect(groups).toHaveLength(1);
       expect(groups[0].group_name).toBe('valid');
     });
@@ -370,21 +400,21 @@ describe('Group Management', () => {
 
     it('should rename a group', () => {
       const result = testFunctions.renameGroup('dev', 'development');
-      
+
       expect(result.changes).toBe(2);
-      
+
       const monitors = testFunctions.getMonitorsByGroup('development');
       expect(monitors).toHaveLength(2);
-      
+
       const oldGroupMonitors = testFunctions.getMonitorsByGroup('dev');
       expect(oldGroupMonitors).toHaveLength(0);
     });
 
     it('should handle case-insensitive rename of same group', () => {
       const result = testFunctions.renameGroup('dev', 'DEV');
-      
+
       expect(result.changes).toBe(2);
-      
+
       const monitors = testFunctions.getMonitorsByGroup('DEV');
       expect(monitors).toHaveLength(2);
       expect(monitors[0].group_name).toBe('DEV');
@@ -398,7 +428,7 @@ describe('Group Management', () => {
 
     it('should throw error when new name already exists', () => {
       testFunctions.addMonitor('http', 'https://prod.com', 60, 'prod1', null, 'prod');
-      
+
       expect(() => {
         testFunctions.renameGroup('dev', 'prod');
       }).toThrow("Group 'prod' already exists.");
@@ -409,7 +439,7 @@ describe('Group Management', () => {
     beforeEach(() => {
       const result1 = testFunctions.addMonitor('http', 'https://dev1.com', 60, 'dev1', null, 'dev');
       const result2 = testFunctions.addMonitor('http', 'https://dev2.com', 60, 'dev2', null, 'dev');
-      
+
       // Add some heartbeats to test cascading
       testFunctions.logHeartbeat(result1.lastInsertRowid, 'up', 100);
       testFunctions.logHeartbeat(result2.lastInsertRowid, 'up', 150);
@@ -417,24 +447,24 @@ describe('Group Management', () => {
 
     it('should ungroup monitors when deleteMonitors is false', () => {
       const result = testFunctions.deleteGroup('dev', false);
-      
+
       expect(result.changes).toBe(2);
-      
+
       // Monitors should still exist but without group
       const monitors = testFunctions.getMonitors();
       expect(monitors).toHaveLength(2);
       expect(monitors[0].group_name).toBeNull();
       expect(monitors[1].group_name).toBeNull();
-      
+
       // Group should no longer exist
       expect(testFunctions.groupExists('dev')).toBe(false);
     });
 
     it('should delete monitors when deleteMonitors is true', () => {
       const result = testFunctions.deleteGroup('dev', true);
-      
+
       expect(result.changes).toBe(2);
-      
+
       // Monitors should be deleted
       const monitors = testFunctions.getMonitors();
       expect(monitors).toHaveLength(0);
@@ -442,7 +472,7 @@ describe('Group Management', () => {
 
     it('should delete heartbeats when deleting monitors', () => {
       testFunctions.deleteGroup('dev', true);
-      
+
       // All heartbeats should be deleted
       const heartbeats = db.prepare('SELECT * FROM heartbeats').all();
       expect(heartbeats).toHaveLength(0);
@@ -470,7 +500,7 @@ describe('Group Management', () => {
 
     it('should return monitors for a specific group', () => {
       const monitors = testFunctions.getMonitorsByGroup('dev');
-      
+
       expect(monitors).toHaveLength(2);
       expect(monitors.every(m => m.group_name === 'dev')).toBe(true);
     });
@@ -482,14 +512,14 @@ describe('Group Management', () => {
 
     it('should return ungrouped monitors when group is null', () => {
       const monitors = testFunctions.getMonitorsByGroup(null);
-      
+
       expect(monitors).toHaveLength(1);
       expect(monitors[0].name).toBe('ungrouped1');
     });
 
     it('should return ungrouped monitors when group is "ungrouped"', () => {
       const monitors = testFunctions.getMonitorsByGroup('ungrouped');
-      
+
       expect(monitors).toHaveLength(1);
       expect(monitors[0].name).toBe('ungrouped1');
     });
@@ -503,17 +533,17 @@ describe('Group Management', () => {
   describe('Edge Cases', () => {
     it('should handle special characters in group names', () => {
       testFunctions.addMonitor('http', 'https://a.com', 60, 'a', null, 'dev-env_1');
-      
+
       const groups = testFunctions.getGroups();
       expect(groups[0].group_name).toBe('dev-env_1');
-      
+
       const monitors = testFunctions.getMonitorsByGroup('dev-env_1');
       expect(monitors).toHaveLength(1);
     });
 
     it('should handle unicode characters in group names', () => {
       testFunctions.addMonitor('http', 'https://a.com', 60, 'a', null, 'développement');
-      
+
       const groups = testFunctions.getGroups();
       expect(groups[0].group_name).toBe('développement');
     });
@@ -521,24 +551,24 @@ describe('Group Management', () => {
     it('should handle very long group names', () => {
       const longName = 'a'.repeat(100);
       testFunctions.addMonitor('http', 'https://a.com', 60, 'a', null, longName);
-      
+
       const groups = testFunctions.getGroups();
       expect(groups[0].group_name).toBe(longName);
     });
 
     it('should handle groups with spaces', () => {
       testFunctions.addMonitor('http', 'https://a.com', 60, 'a', null, 'dev environment');
-      
+
       const monitors = testFunctions.getMonitorsByGroup('dev environment');
       expect(monitors).toHaveLength(1);
     });
 
     it('should handle renaming to same name with different case', () => {
       testFunctions.addMonitor('http', 'https://a.com', 60, 'a', null, 'dev');
-      
+
       const result = testFunctions.renameGroup('dev', 'Dev');
       expect(result.changes).toBe(1);
-      
+
       const monitors = testFunctions.getMonitorsByGroup('Dev');
       expect(monitors[0].group_name).toBe('Dev');
     });
@@ -546,15 +576,17 @@ describe('Group Management', () => {
     it('should properly clean up when deleting group with SSL certificates', () => {
       const result = testFunctions.addMonitor('ssl', 'github.com', 3600, 'ssl-mon', null, 'ssl-group');
       const monitorId = result.lastInsertRowid;
-      
+
       // Add SSL certificate
-      db.prepare(`
+      db.prepare(
+        `
         INSERT INTO ssl_certificates (monitor_id, issuer, subject, valid_from, valid_to, days_remaining, serial_number, fingerprint)
         VALUES (?, 'DigiCert', 'github.com', '2024-01-01', '2025-01-01', 365, 'ABC123', 'SHA256:XYZ')
-      `).run(monitorId);
-      
+      `
+      ).run(monitorId);
+
       testFunctions.deleteGroup('ssl-group', true);
-      
+
       const certs = db.prepare('SELECT * FROM ssl_certificates WHERE monitor_id = ?').all(monitorId);
       expect(certs).toHaveLength(0);
     });
@@ -565,16 +597,16 @@ describe('Group Management', () => {
       // Simulate existing monitors without groups
       testFunctions.addMonitor('http', 'https://old1.com', 60, 'old1', null, null);
       testFunctions.addMonitor('http', 'https://old2.com', 60, 'old2', null, null);
-      
+
       // Add new monitors with groups
       testFunctions.addMonitor('http', 'https://new1.com', 60, 'new1', null, 'dev');
-      
+
       const allMonitors = testFunctions.getMonitors();
       expect(allMonitors).toHaveLength(3);
-      
+
       const groups = testFunctions.getGroups();
       expect(groups).toHaveLength(1);
-      
+
       const ungrouped = testFunctions.getMonitorsByGroup(null);
       expect(ungrouped).toHaveLength(2);
     });
@@ -582,9 +614,9 @@ describe('Group Management', () => {
     it('should allow updating existing monitor to add group', () => {
       const result = testFunctions.addMonitor('http', 'https://existing.com', 60, 'existing', null, null);
       const monitorId = result.lastInsertRowid;
-      
+
       testFunctions.updateMonitor(monitorId, { group_name: 'newly-grouped' });
-      
+
       const monitor = testFunctions.getMonitorByIdOrName(String(monitorId));
       expect(monitor.group_name).toBe('newly-grouped');
     });

--- a/tests/core/notifier.test.js
+++ b/tests/core/notifier.test.js
@@ -39,7 +39,7 @@ describe('Notifier Module', () => {
   describe('sendNotification', () => {
     it('should call notifier.notify with correct parameters', () => {
       sendNotification('Test Title', 'Test Message');
-      
+
       expect(notifier.notify).toHaveBeenCalledTimes(1);
       expect(notifier.notify).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -52,7 +52,7 @@ describe('Notifier Module', () => {
 
     it('should include custom options', () => {
       sendNotification('Title', 'Message', { sound: false });
-      
+
       expect(notifier.notify).toHaveBeenCalledWith(
         expect.objectContaining({
           sound: false
@@ -70,7 +70,7 @@ describe('Notifier Module', () => {
 
     it('should send webhook for monitor_down event', async () => {
       await sendWebhook(mockMonitor.webhook_url, 'monitor_down', mockMonitor);
-      
+
       expect(axios.post).toHaveBeenCalledTimes(1);
       expect(axios.post).toHaveBeenCalledWith(
         'https://webhook.example.com/hook',
@@ -87,7 +87,7 @@ describe('Notifier Module', () => {
 
     it('should send webhook for monitor_up event', async () => {
       await sendWebhook(mockMonitor.webhook_url, 'monitor_up', mockMonitor);
-      
+
       expect(axios.post).toHaveBeenCalledWith(
         'https://webhook.example.com/hook',
         expect.objectContaining({
@@ -101,30 +101,29 @@ describe('Notifier Module', () => {
 
     it('should not send webhook when webhookUrl is null', async () => {
       await sendWebhook(null, 'monitor_down', mockMonitor);
-      
+
       expect(axios.post).not.toHaveBeenCalled();
     });
 
     it('should not send webhook when webhookUrl is undefined', async () => {
       await sendWebhook(undefined, 'monitor_down', mockMonitor);
-      
+
       expect(axios.post).not.toHaveBeenCalled();
     });
 
     it('should handle webhook errors gracefully', async () => {
       axios.post.mockRejectedValueOnce(new Error('Network error'));
-      
-      await expect(sendWebhook(mockMonitor.webhook_url, 'monitor_down', mockMonitor))
-        .resolves.not.toThrow();
+
+      await expect(sendWebhook(mockMonitor.webhook_url, 'monitor_down', mockMonitor)).resolves.not.toThrow();
     });
   });
 
   describe('notifyMonitorDown', () => {
     it('should send notification with monitor name', () => {
       const monitor = { name: 'My Site', url: 'https://mysite.com', webhook_url: null };
-      
+
       notifyMonitorDown(monitor);
-      
+
       expect(notifier.notify).toHaveBeenCalledWith(
         expect.objectContaining({
           title: '❌ Monitor Down',
@@ -135,9 +134,9 @@ describe('Notifier Module', () => {
 
     it('should fallback to URL when name is not set', () => {
       const monitor = { name: null, url: 'https://mysite.com', webhook_url: null };
-      
+
       notifyMonitorDown(monitor);
-      
+
       expect(notifier.notify).toHaveBeenCalledWith(
         expect.objectContaining({
           message: 'https://mysite.com is not responding'
@@ -151,9 +150,9 @@ describe('Notifier Module', () => {
         url: 'https://mysite.com',
         webhook_url: 'https://webhook.example.com'
       };
-      
+
       notifyMonitorDown(monitor);
-      
+
       expect(axios.post).toHaveBeenCalled();
     });
   });
@@ -161,9 +160,9 @@ describe('Notifier Module', () => {
   describe('notifyMonitorUp', () => {
     it('should send notification with monitor name', () => {
       const monitor = { name: 'My Site', url: 'https://mysite.com', webhook_url: null };
-      
+
       notifyMonitorUp(monitor);
-      
+
       expect(notifier.notify).toHaveBeenCalledWith(
         expect.objectContaining({
           title: '✅ Monitor Back Up',
@@ -178,9 +177,9 @@ describe('Notifier Module', () => {
         url: 'https://mysite.com',
         webhook_url: 'https://webhook.example.com'
       };
-      
+
       notifyMonitorUp(monitor);
-      
+
       expect(axios.post).toHaveBeenCalled();
     });
   });
@@ -190,7 +189,7 @@ describe('Notifier Module', () => {
 
     it('should send critical notification when days <= 7', () => {
       notifySSLExpiring(monitor, 5);
-      
+
       expect(notifier.notify).toHaveBeenCalledWith(
         expect.objectContaining({
           title: '🚨 SSL Certificate Critical',
@@ -201,7 +200,7 @@ describe('Notifier Module', () => {
 
     it('should send warning notification when days <= 14', () => {
       notifySSLExpiring(monitor, 10);
-      
+
       expect(notifier.notify).toHaveBeenCalledWith(
         expect.objectContaining({
           title: '⚠️ SSL Certificate Warning',
@@ -212,7 +211,7 @@ describe('Notifier Module', () => {
 
     it('should not send notification when days > 14', () => {
       notifySSLExpiring(monitor, 30);
-      
+
       expect(notifier.notify).not.toHaveBeenCalled();
     });
 
@@ -221,9 +220,9 @@ describe('Notifier Module', () => {
         ...monitor,
         webhook_url: 'https://webhook.example.com'
       };
-      
+
       notifySSLExpiring(monitorWithWebhook, 5);
-      
+
       expect(axios.post).toHaveBeenCalledWith(
         'https://webhook.example.com',
         expect.objectContaining({
@@ -236,9 +235,9 @@ describe('Notifier Module', () => {
   describe('notifySSLExpired', () => {
     it('should send expired notification', () => {
       const monitor = { name: 'SSL Site', url: 'https://secure.com', webhook_url: null };
-      
+
       notifySSLExpired(monitor);
-      
+
       expect(notifier.notify).toHaveBeenCalledWith(
         expect.objectContaining({
           title: '❌ SSL Certificate Expired',
@@ -251,9 +250,9 @@ describe('Notifier Module', () => {
   describe('notifySSLValid', () => {
     it('should send valid notification', () => {
       const monitor = { name: 'SSL Site', url: 'https://secure.com', webhook_url: null };
-      
+
       notifySSLValid(monitor);
-      
+
       expect(notifier.notify).toHaveBeenCalledWith(
         expect.objectContaining({
           title: '✅ SSL Certificate Valid',

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -12,6 +12,5 @@ afterEach(() => {
 });
 
 afterAll(async () => {
-
   await new Promise(resolve => setTimeout(resolve, 100));
 });

--- a/tests/ui/__snapshots__/snapshot.test.js.snap
+++ b/tests/ui/__snapshots__/snapshot.test.js.snap
@@ -7,8 +7,8 @@ exports[`Dashboard Component Snapshots should maintain consistent column widths 
 │                                                                                                  │
 │ Uptime Monitors                                                                                  │
 │ ┌──────────────────────────────────────────────────────────────────────────────────────────────┐ │
-│ │ #   Name         Group    URL            Type   Status Latency Uptime    Last Downtime       │ │
-│ │                                                                (24h)                         │ │
+│ │ #   Name         Group    URL            Type   Status  Latency  Uptime    Last Downtime     │ │
+│ │                                                                  (24h)                       │ │
 │ └──────────────────────────────────────────────────────────────────────────────────────────────┘ │
 │ │ 1   VeryLongMoni -        very-long...le.http   ✔ UP   100ms   99.99%    None                │ │
 │ │     torNameThatS          com                                                                │ │
@@ -68,8 +68,8 @@ exports[`Dashboard Component Snapshots should render mixed regular and SSL monit
 │                                                                                                  │
 │ Uptime Monitors                                                                                  │
 │ ┌──────────────────────────────────────────────────────────────────────────────────────────────┐ │
-│ │ #   Name         Group    URL            Type   Status Latency Uptime    Last Downtime       │ │
-│ │                                                                (24h)                         │ │
+│ │ #   Name         Group    URL            Type   Status  Latency  Uptime    Last Downtime     │ │
+│ │                                                                  (24h)                       │ │
 │ └──────────────────────────────────────────────────────────────────────────────────────────────┘ │
 │ │ 1   Main Site    -        mainsite.com   http   ✔ UP   95ms    99.95%    None                │ │
 │ └──────────────────────────────────────────────────────────────────────────────────────────────┘ │
@@ -109,8 +109,8 @@ exports[`Dashboard Component Snapshots should render with multiple monitors (mix
 │                                                                                                  │
 │ Uptime Monitors                                                                                  │
 │ ┌──────────────────────────────────────────────────────────────────────────────────────────────┐ │
-│ │ #   Name         Group    URL            Type   Status Latency Uptime    Last Downtime       │ │
-│ │                                                                (24h)                         │ │
+│ │ #   Name         Group    URL            Type   Status  Latency  Uptime    Last Downtime     │ │
+│ │                                                                  (24h)                       │ │
 │ └──────────────────────────────────────────────────────────────────────────────────────────────┘ │
 │ │ 1   Website      -        example.com    http   ✔ UP   120ms   99.99%    None                │ │
 │ └──────────────────────────────────────────────────────────────────────────────────────────────┘ │
@@ -130,8 +130,8 @@ exports[`Dashboard Component Snapshots should render with single HTTP monitor DO
 │                                                                                                  │
 │ Uptime Monitors                                                                                  │
 │ ┌──────────────────────────────────────────────────────────────────────────────────────────────┐ │
-│ │ #   Name         Group    URL            Type   Status Latency Uptime    Last Downtime       │ │
-│ │                                                                (24h)                         │ │
+│ │ #   Name         Group    URL            Type   Status  Latency  Uptime    Last Downtime     │ │
+│ │                                                                  (24h)                       │ │
 │ └──────────────────────────────────────────────────────────────────────────────────────────────┘ │
 │ │ 1   Example      -        example.com    http   ✖ DOWN 0ms     85.00%    5 minutes ago       │ │
 │ └──────────────────────────────────────────────────────────────────────────────────────────────┘ │
@@ -147,8 +147,8 @@ exports[`Dashboard Component Snapshots should render with single HTTP monitor UP
 │                                                                                                  │
 │ Uptime Monitors                                                                                  │
 │ ┌──────────────────────────────────────────────────────────────────────────────────────────────┐ │
-│ │ #   Name         Group    URL            Type   Status Latency Uptime    Last Downtime       │ │
-│ │                                                                (24h)                         │ │
+│ │ #   Name         Group    URL            Type   Status  Latency  Uptime    Last Downtime     │ │
+│ │                                                                  (24h)                       │ │
 │ └──────────────────────────────────────────────────────────────────────────────────────────────┘ │
 │ │ 1   Example      -        example.com    http   ✔ UP   150ms   99.50%    None                │ │
 │ └──────────────────────────────────────────────────────────────────────────────────────────────┘ │
@@ -164,8 +164,8 @@ exports[`Dashboard Component Snapshots should show correct counts in header (up/
 │                                                                                                  │
 │ Uptime Monitors                                                                                  │
 │ ┌──────────────────────────────────────────────────────────────────────────────────────────────┐ │
-│ │ #   Name         Group    URL            Type   Status Latency Uptime    Last Downtime       │ │
-│ │                                                                (24h)                         │ │
+│ │ #   Name         Group    URL            Type   Status  Latency  Uptime    Last Downtime     │ │
+│ │                                                                  (24h)                       │ │
 │ └──────────────────────────────────────────────────────────────────────────────────────────────┘ │
 │ │ 1   Up1          -        up1.com        http   ✔ UP   100ms   100%      None                │ │
 │ └──────────────────────────────────────────────────────────────────────────────────────────────┘ │

--- a/tests/ui/snapshot.test.js
+++ b/tests/ui/snapshot.test.js
@@ -7,18 +7,23 @@ import React from 'react';
 import { render } from 'ink-testing-library';
 import { Text, Box } from 'ink';
 
-
-const StatBox = ({ label, value, color = "white" }) => (
+const StatBox = ({ label, value, color = 'white' }) => (
   <Box flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1} flexGrow={1} marginRight={1}>
-    <Text color="gray" dimColor>{label}</Text>
-    <Text bold color={color}>{value}</Text>
+    <Text color="gray" dimColor>
+      {label}
+    </Text>
+    <Text bold color={color}>
+      {value}
+    </Text>
   </Box>
 );
 
 // Dashboard Header component
 const DashboardHeader = ({ upCount, downCount, groupFilter = null }) => (
   <Box marginBottom={1}>
-    <Text bold color="cyan">UptimeKit Dashboard</Text>
+    <Text bold color="cyan">
+      UptimeKit Dashboard
+    </Text>
     {groupFilter && (
       <Box marginLeft={2}>
         <Text color="yellow">Group: {groupFilter}</Text>
@@ -58,11 +63,21 @@ const MonitorRow = ({ monitor }) => {
 
   return (
     <Box borderStyle="single" borderColor="gray" borderTop={false} paddingX={1}>
-      <Box width="5%"><Text>{monitor.id}</Text></Box>
-      <Box width="15%"><Text>{displayName}</Text></Box>
-      <Box width="10%"><Text color="cyan">{displayGroup}</Text></Box>
-      <Box width="18%"><Text>{displayUrl}</Text></Box>
-      <Box width="8%"><Text>{monitor.type}</Text></Box>
+      <Box width="5%">
+        <Text>{monitor.id}</Text>
+      </Box>
+      <Box width="15%">
+        <Text>{displayName}</Text>
+      </Box>
+      <Box width="10%">
+        <Text color="cyan">{displayGroup}</Text>
+      </Box>
+      <Box width="18%">
+        <Text>{displayUrl}</Text>
+      </Box>
+      <Box width="8%">
+        <Text>{monitor.type}</Text>
+      </Box>
       <Box width="9%">
         <Text color={monitor.status === 'up' ? 'green' : 'red'} bold>
           {monitor.status === 'up' ? '✔ UP' : '✖ DOWN'}
@@ -106,14 +121,30 @@ const SSLMonitorRow = ({ monitor }) => {
   let statusDisplay;
   if (monitor.status === 'up') {
     if (days !== null && days <= 7) {
-      statusDisplay = <Text color="red" bold>⚠ EXPIRING</Text>;
+      statusDisplay = (
+        <Text color="red" bold>
+          ⚠ EXPIRING
+        </Text>
+      );
     } else if (days !== null && days <= 30) {
-      statusDisplay = <Text color="yellow" bold>⚠ WARNING</Text>;
+      statusDisplay = (
+        <Text color="yellow" bold>
+          ⚠ WARNING
+        </Text>
+      );
     } else {
-      statusDisplay = <Text color="green" bold>✔ VALID</Text>;
+      statusDisplay = (
+        <Text color="green" bold>
+          ✔ VALID
+        </Text>
+      );
     }
   } else {
-    statusDisplay = <Text color="red" bold>✖ INVALID</Text>;
+    statusDisplay = (
+      <Text color="red" bold>
+        ✖ INVALID
+      </Text>
+    );
   }
 
   const expiryDate = ssl.validTo ? new Date(ssl.validTo).toLocaleDateString('en-US') : 'Unknown';
@@ -121,15 +152,29 @@ const SSLMonitorRow = ({ monitor }) => {
 
   return (
     <Box borderStyle="single" borderColor="gray" borderTop={false} paddingX={1}>
-      <Box width="6%"><Text>{monitor.id}</Text></Box>
-      <Box width="19%"><Text>{displayName}</Text></Box>
-      <Box width="23%"><Text>{displayHost}</Text></Box>
+      <Box width="6%">
+        <Text>{monitor.id}</Text>
+      </Box>
+      <Box width="19%">
+        <Text>{displayName}</Text>
+      </Box>
+      <Box width="23%">
+        <Text>{displayHost}</Text>
+      </Box>
       <Box width="14%">{statusDisplay}</Box>
       <Box width="12%">
-        <Text color={daysColor} bold>{days !== null && days !== undefined ? `${days} days` : 'N/A'}</Text>
+        <Text color={daysColor} bold>
+          {days !== null && days !== undefined ? `${days} days` : 'N/A'}
+        </Text>
       </Box>
-      <Box width="16%"><Text color="gray">{expiryDate}</Text></Box>
-      <Box width="20%"><Text color="gray" dimColor>{issuer}</Text></Box>
+      <Box width="16%">
+        <Text color="gray">{expiryDate}</Text>
+      </Box>
+      <Box width="20%">
+        <Text color="gray" dimColor>
+          {issuer}
+        </Text>
+      </Box>
     </Box>
   );
 };
@@ -162,41 +207,115 @@ const SimpleDashboard = ({ monitors = [], groupFilter = null, groups = [] }) => 
 
       {regularMonitors.length > 0 && (
         <Box flexDirection="column" marginBottom={1}>
-          <Text bold color="white" marginBottom={1}>Uptime Monitors</Text>
+          <Text bold color="white" marginBottom={1}>
+            Uptime Monitors
+          </Text>
           <Box borderStyle="single" borderColor="gray" paddingX={1}>
-            <Box width="5%"><Text bold color="blue">#</Text></Box>
-            <Box width="15%"><Text bold color="blue">Name</Text></Box>
-            <Box width="10%"><Text bold color="blue">Group</Text></Box>
-            <Box width="18%"><Text bold color="blue">URL</Text></Box>
-            <Box width="8%"><Text bold color="blue">Type</Text></Box>
-            <Box width="9%"><Text bold color="blue">Status</Text></Box>
-            <Box width="9%"><Text bold color="blue">Latency</Text></Box>
-            <Box width="12%"><Text bold color="blue">Uptime (24h)</Text></Box>
-            <Box width="22%"><Text bold color="blue">Last Downtime</Text></Box>
+            <Box width="5%">
+              <Text bold color="blue">
+                #
+              </Text>
+            </Box>
+            <Box width="15%">
+              <Text bold color="blue">
+                Name
+              </Text>
+            </Box>
+            <Box width="10%">
+              <Text bold color="blue">
+                Group
+              </Text>
+            </Box>
+            <Box width="18%">
+              <Text bold color="blue">
+                URL
+              </Text>
+            </Box>
+            <Box width="8%">
+              <Text bold color="blue">
+                Type
+              </Text>
+            </Box>
+            <Box width="9%">
+              <Text bold color="blue">
+                Status
+              </Text>
+            </Box>
+            <Box width="9%">
+              <Text bold color="blue">
+                Latency
+              </Text>
+            </Box>
+            <Box width="12%">
+              <Text bold color="blue">
+                Uptime (24h)
+              </Text>
+            </Box>
+            <Box width="22%">
+              <Text bold color="blue">
+                Last Downtime
+              </Text>
+            </Box>
           </Box>
-          {regularMonitors.map((m) => <MonitorRow key={m.id} monitor={m} />)}
+          {regularMonitors.map(m => (
+            <MonitorRow key={m.id} monitor={m} />
+          ))}
         </Box>
       )}
 
       {sslMonitors.length > 0 && (
         <Box flexDirection="column">
-          <Text bold color="white" marginBottom={1}>SSL Certificate Monitors</Text>
+          <Text bold color="white" marginBottom={1}>
+            SSL Certificate Monitors
+          </Text>
           <Box borderStyle="single" borderColor="gray" paddingX={1}>
-            <Box width="6%"><Text bold color="magenta">#</Text></Box>
-            <Box width="19%"><Text bold color="magenta">Name</Text></Box>
-            <Box width="23%"><Text bold color="magenta">Host</Text></Box>
-            <Box width="14%"><Text bold color="magenta">Status</Text></Box>
-            <Box width="12%"><Text bold color="magenta">Days Left</Text></Box>
-            <Box width="16%"><Text bold color="magenta">Expires</Text></Box>
-            <Box width="20%"><Text bold color="magenta">Issuer</Text></Box>
+            <Box width="6%">
+              <Text bold color="magenta">
+                #
+              </Text>
+            </Box>
+            <Box width="19%">
+              <Text bold color="magenta">
+                Name
+              </Text>
+            </Box>
+            <Box width="23%">
+              <Text bold color="magenta">
+                Host
+              </Text>
+            </Box>
+            <Box width="14%">
+              <Text bold color="magenta">
+                Status
+              </Text>
+            </Box>
+            <Box width="12%">
+              <Text bold color="magenta">
+                Days Left
+              </Text>
+            </Box>
+            <Box width="16%">
+              <Text bold color="magenta">
+                Expires
+              </Text>
+            </Box>
+            <Box width="20%">
+              <Text bold color="magenta">
+                Issuer
+              </Text>
+            </Box>
           </Box>
-          {sslMonitors.map((m) => <SSLMonitorRow key={m.id} monitor={m} />)}
+          {sslMonitors.map(m => (
+            <SSLMonitorRow key={m.id} monitor={m} />
+          ))}
         </Box>
       )}
 
       {monitors.length === 0 && (
         <Box marginTop={1} paddingX={1}>
-          <Text italic color="yellow">No monitors found. Run `uptimekit add` to add one.</Text>
+          <Text italic color="yellow">
+            No monitors found. Run `uptimekit add` to add one.
+          </Text>
         </Box>
       )}
     </Box>
@@ -222,9 +341,7 @@ const SimpleMonitorDetail = ({ monitor, heartbeats = [], sslCert = null, notFoun
   }
 
   const isSSL = monitor.type === 'ssl';
-  const latencies = heartbeats
-    .filter(h => typeof h.latency === 'number')
-    .map(h => h.latency);
+  const latencies = heartbeats.filter(h => typeof h.latency === 'number').map(h => h.latency);
   const total = heartbeats.length;
   const up = heartbeats.filter(h => h.status === 'up').length;
   const currentStatus = heartbeats[0]?.status || 'unknown';
@@ -238,32 +355,39 @@ const SimpleMonitorDetail = ({ monitor, heartbeats = [], sslCert = null, notFoun
   };
 
   const isUp = stats.currentStatus === 'up';
-  let statusColor = isUp ? "green" : "red";
-  let statusText = isUp ? "  ONLINE  " : "  OFFLINE  ";
+  let statusColor = isUp ? 'green' : 'red';
+  let statusText = isUp ? '  ONLINE  ' : '  OFFLINE  ';
 
   if (isSSL && sslCert) {
     const days = sslCert.days_remaining;
     if (isUp) {
       if (days <= 7) {
-        statusColor = "red";
-        statusText = " EXPIRING ";
+        statusColor = 'red';
+        statusText = ' EXPIRING ';
       } else if (days <= 30) {
-        statusColor = "yellow";
-        statusText = " WARNING  ";
+        statusColor = 'yellow';
+        statusText = ' WARNING  ';
       } else {
-        statusColor = "green";
-        statusText = "  VALID   ";
+        statusColor = 'green';
+        statusText = '  VALID   ';
       }
     } else {
-      statusColor = "red";
-      statusText = " INVALID  ";
+      statusColor = 'red';
+      statusText = ' INVALID  ';
     }
   }
 
-  const historyBar = heartbeats.slice(0, 40).reverse().map((h, i) => {
-    const up = h.status === 'up';
-    return <Text key={i} color={up ? "green" : "red"}>■</Text>;
-  });
+  const historyBar = heartbeats
+    .slice(0, 40)
+    .reverse()
+    .map((h, i) => {
+      const up = h.status === 'up';
+      return (
+        <Text key={i} color={up ? 'green' : 'red'}>
+          ■
+        </Text>
+      );
+    });
 
   if (isSSL) {
     const cert = sslCert || {};
@@ -279,46 +403,76 @@ const SimpleMonitorDetail = ({ monitor, heartbeats = [], sslCert = null, notFoun
         <Box justifyContent="space-between" marginBottom={1}>
           <Box flexDirection="column">
             <Box alignItems="center">
-              <Text bold color="white" backgroundColor={statusColor}>{statusText}</Text>
+              <Text bold color="white" backgroundColor={statusColor}>
+                {statusText}
+              </Text>
               <Box marginLeft={1}>
-                <Text bold color="white" underline>{monitor.name || "SSL Monitor"}</Text>
+                <Text bold color="white" underline>
+                  {monitor.name || 'SSL Monitor'}
+                </Text>
               </Box>
             </Box>
             <Box marginTop={1}>
               <Text color="cyan">{monitor.url}</Text>
             </Box>
-            <Text color="gray" dimColor>Type: SSL Certificate • Interval: {monitor.interval}s</Text>
+            <Text color="gray" dimColor>
+              Type: SSL Certificate • Interval: {monitor.interval}s
+            </Text>
             {monitor.group_name && (
-              <Text color="gray" dimColor>Group: <Text color="magenta">{monitor.group_name}</Text></Text>
+              <Text color="gray" dimColor>
+                Group: <Text color="magenta">{monitor.group_name}</Text>
+              </Text>
             )}
           </Box>
           <Box flexDirection="column" alignItems="flex-end">
-            <Text color="gray" dimColor>ID: {monitor.id}</Text>
-            <Text color="gray" dimColor>Press 'q' to quit</Text>
+            <Text color="gray" dimColor>
+              ID: {monitor.id}
+            </Text>
+            <Text color="gray" dimColor>
+              Press 'q' to quit
+            </Text>
           </Box>
         </Box>
 
         <Box flexDirection="column" marginBottom={1}>
-          <Text bold color="white">Certificate Status History (Last 40 checks)</Text>
+          <Text bold color="white">
+            Certificate Status History (Last 40 checks)
+          </Text>
           <Box borderStyle="single" borderColor="gray" paddingX={1}>
             {historyBar.length > 0 ? historyBar : <Text color="gray">No data yet...</Text>}
           </Box>
         </Box>
 
         <Box flexDirection="column" marginBottom={1} borderStyle="single" borderColor="gray" padding={1}>
-          <Text bold color="white" underline>SSL Certificate Details</Text>
+          <Text bold color="white" underline>
+            SSL Certificate Details
+          </Text>
           <Box marginTop={1} flexDirection="column">
             <Box>
-              <Box width="20%"><Text color="gray">Subject:</Text></Box>
-              <Box><Text color="cyan">{cert.subject || 'Unknown'}</Text></Box>
+              <Box width="20%">
+                <Text color="gray">Subject:</Text>
+              </Box>
+              <Box>
+                <Text color="cyan">{cert.subject || 'Unknown'}</Text>
+              </Box>
             </Box>
             <Box>
-              <Box width="20%"><Text color="gray">Issuer:</Text></Box>
-              <Box><Text>{cert.issuer || 'Unknown'}</Text></Box>
+              <Box width="20%">
+                <Text color="gray">Issuer:</Text>
+              </Box>
+              <Box>
+                <Text>{cert.issuer || 'Unknown'}</Text>
+              </Box>
             </Box>
             <Box>
-              <Box width="20%"><Text color="gray">Days Remaining:</Text></Box>
-              <Box><Text color={daysColor}>{daysRemaining !== null && daysRemaining !== undefined ? `${daysRemaining} days` : 'N/A'}</Text></Box>
+              <Box width="20%">
+                <Text color="gray">Days Remaining:</Text>
+              </Box>
+              <Box>
+                <Text color={daysColor}>
+                  {daysRemaining !== null && daysRemaining !== undefined ? `${daysRemaining} days` : 'N/A'}
+                </Text>
+              </Box>
             </Box>
           </Box>
         </Box>
@@ -329,7 +483,11 @@ const SimpleMonitorDetail = ({ monitor, heartbeats = [], sslCert = null, notFoun
             value={daysRemaining !== null && daysRemaining !== undefined ? `${daysRemaining} days` : 'N/A'}
             color={daysColor}
           />
-          <StatBox label="Validity Rate" value={`${stats.uptime}%`} color={parseFloat(stats.uptime) > 99 ? "green" : "yellow"} />
+          <StatBox
+            label="Validity Rate"
+            value={`${stats.uptime}%`}
+            color={parseFloat(stats.uptime) > 99 ? 'green' : 'yellow'}
+          />
         </Box>
       </Box>
     );
@@ -340,32 +498,47 @@ const SimpleMonitorDetail = ({ monitor, heartbeats = [], sslCert = null, notFoun
       <Box justifyContent="space-between" marginBottom={1}>
         <Box flexDirection="column">
           <Box alignItems="center">
-            <Text bold color="white" backgroundColor={statusColor}>{statusText}</Text>
+            <Text bold color="white" backgroundColor={statusColor}>
+              {statusText}
+            </Text>
             <Box marginLeft={1}>
-              <Text bold color="white" underline>{monitor.name || "Monitor"}</Text>
+              <Text bold color="white" underline>
+                {monitor.name || 'Monitor'}
+              </Text>
             </Box>
           </Box>
           <Box marginTop={1}>
             <Text color="cyan">{monitor.url}</Text>
           </Box>
-          <Text color="gray" dimColor>Type: {monitor.type} • Interval: {monitor.interval}s</Text>
+          <Text color="gray" dimColor>
+            Type: {monitor.type} • Interval: {monitor.interval}s
+          </Text>
           {monitor.group_name && (
-            <Text color="gray" dimColor>Group: <Text color="magenta">{monitor.group_name}</Text></Text>
+            <Text color="gray" dimColor>
+              Group: <Text color="magenta">{monitor.group_name}</Text>
+            </Text>
           )}
           {monitor.webhook_url && (
             <Text color="gray" dimColor>
-              Webhook: {monitor.webhook_url.length > 50 ? monitor.webhook_url.substring(0, 47) + '...' : monitor.webhook_url}
+              Webhook:{' '}
+              {monitor.webhook_url.length > 50 ? monitor.webhook_url.substring(0, 47) + '...' : monitor.webhook_url}
             </Text>
           )}
         </Box>
         <Box flexDirection="column" alignItems="flex-end">
-          <Text color="gray" dimColor>ID: {monitor.id}</Text>
-          <Text color="gray" dimColor>Press 'q' to quit</Text>
+          <Text color="gray" dimColor>
+            ID: {monitor.id}
+          </Text>
+          <Text color="gray" dimColor>
+            Press 'q' to quit
+          </Text>
         </Box>
       </Box>
 
       <Box flexDirection="column" marginBottom={1}>
-        <Text bold color="white">Recent Checks (Last 40)</Text>
+        <Text bold color="white">
+          Recent Checks (Last 40)
+        </Text>
         <Box borderStyle="single" borderColor="gray" paddingX={1}>
           {historyBar.length > 0 ? historyBar : <Text color="gray">No data yet...</Text>}
         </Box>
@@ -375,7 +548,11 @@ const SimpleMonitorDetail = ({ monitor, heartbeats = [], sslCert = null, notFoun
         <StatBox label="Current" value={`${latencies[latencies.length - 1] || 0} ms`} color={statusColor} />
         <StatBox label="Avg Latency" value={`${stats.avg} ms`} />
         <StatBox label="Max Latency" value={`${stats.max} ms`} />
-        <StatBox label="Uptime (24h)" value={`${stats.uptime}%`} color={parseFloat(stats.uptime) > 99 ? "green" : "yellow"} />
+        <StatBox
+          label="Uptime (24h)"
+          value={`${stats.uptime}%`}
+          color={parseFloat(stats.uptime) > 99 ? 'green' : 'yellow'}
+        />
       </Box>
     </Box>
   );
@@ -389,19 +566,21 @@ describe('Dashboard Component Snapshots', () => {
   });
 
   it('should render with single HTTP monitor UP', () => {
-    const monitors = [{
-      id: 1,
-      name: 'Example',
-      type: 'http',
-      url: 'https://example.com',
-      interval: 60,
-      uptime: '99.50',
-      lastDowntime: 'No downtime',
-      status: 'up',
-      latency: 150,
-      lastCheck: '30 seconds ago',
-      ssl: null
-    }];
+    const monitors = [
+      {
+        id: 1,
+        name: 'Example',
+        type: 'http',
+        url: 'https://example.com',
+        interval: 60,
+        uptime: '99.50',
+        lastDowntime: 'No downtime',
+        status: 'up',
+        latency: 150,
+        lastCheck: '30 seconds ago',
+        ssl: null
+      }
+    ];
 
     const { lastFrame, unmount } = render(<SimpleDashboard monitors={monitors} />);
     expect(lastFrame()).toMatchSnapshot();
@@ -409,19 +588,21 @@ describe('Dashboard Component Snapshots', () => {
   });
 
   it('should render with single HTTP monitor DOWN', () => {
-    const monitors = [{
-      id: 1,
-      name: 'Example',
-      type: 'http',
-      url: 'https://example.com',
-      interval: 60,
-      uptime: '85.00',
-      lastDowntime: '5 minutes ago',
-      status: 'down',
-      latency: 0,
-      lastCheck: '10 seconds ago',
-      ssl: null
-    }];
+    const monitors = [
+      {
+        id: 1,
+        name: 'Example',
+        type: 'http',
+        url: 'https://example.com',
+        interval: 60,
+        uptime: '85.00',
+        lastDowntime: '5 minutes ago',
+        status: 'down',
+        latency: 0,
+        lastCheck: '10 seconds ago',
+        ssl: null
+      }
+    ];
 
     const { lastFrame, unmount } = render(<SimpleDashboard monitors={monitors} />);
     expect(lastFrame()).toMatchSnapshot();
@@ -430,9 +611,45 @@ describe('Dashboard Component Snapshots', () => {
 
   it('should render with multiple monitors (mixed types)', () => {
     const monitors = [
-      { id: 1, name: 'Website', type: 'http', url: 'https://example.com', interval: 60, uptime: '99.99', lastDowntime: 'No downtime', status: 'up', latency: 120, lastCheck: '15 seconds ago', ssl: null },
-      { id: 2, name: 'Google DNS', type: 'icmp', url: '8.8.8.8', interval: 30, uptime: '100.00', lastDowntime: 'No downtime', status: 'up', latency: 25, lastCheck: '5 seconds ago', ssl: null },
-      { id: 3, name: 'DNS Check', type: 'dns', url: 'google.com', interval: 120, uptime: '99.80', lastDowntime: '2 hours ago', status: 'up', latency: 45, lastCheck: '1 minute ago', ssl: null }
+      {
+        id: 1,
+        name: 'Website',
+        type: 'http',
+        url: 'https://example.com',
+        interval: 60,
+        uptime: '99.99',
+        lastDowntime: 'No downtime',
+        status: 'up',
+        latency: 120,
+        lastCheck: '15 seconds ago',
+        ssl: null
+      },
+      {
+        id: 2,
+        name: 'Google DNS',
+        type: 'icmp',
+        url: '8.8.8.8',
+        interval: 30,
+        uptime: '100.00',
+        lastDowntime: 'No downtime',
+        status: 'up',
+        latency: 25,
+        lastCheck: '5 seconds ago',
+        ssl: null
+      },
+      {
+        id: 3,
+        name: 'DNS Check',
+        type: 'dns',
+        url: 'google.com',
+        interval: 120,
+        uptime: '99.80',
+        lastDowntime: '2 hours ago',
+        status: 'up',
+        latency: 45,
+        lastCheck: '1 minute ago',
+        ssl: null
+      }
     ];
 
     const { lastFrame, unmount } = render(<SimpleDashboard monitors={monitors} />);
@@ -441,25 +658,27 @@ describe('Dashboard Component Snapshots', () => {
   });
 
   it('should render with SSL monitors', () => {
-    const monitors = [{
-      id: 1,
-      name: 'GitHub SSL',
-      type: 'ssl',
-      url: 'github.com',
-      interval: 3600,
-      uptime: '100.00',
-      lastDowntime: 'No downtime',
-      status: 'up',
-      latency: 250,
-      lastCheck: '10 minutes ago',
-      ssl: {
-        issuer: 'DigiCert',
-        subject: 'github.com',
-        validFrom: '2024-01-01',
-        validTo: '2025-01-01',
-        daysRemaining: 180
+    const monitors = [
+      {
+        id: 1,
+        name: 'GitHub SSL',
+        type: 'ssl',
+        url: 'github.com',
+        interval: 3600,
+        uptime: '100.00',
+        lastDowntime: 'No downtime',
+        status: 'up',
+        latency: 250,
+        lastCheck: '10 minutes ago',
+        ssl: {
+          issuer: 'DigiCert',
+          subject: 'github.com',
+          validFrom: '2024-01-01',
+          validTo: '2025-01-01',
+          daysRemaining: 180
+        }
       }
-    }];
+    ];
 
     const { lastFrame, unmount } = render(<SimpleDashboard monitors={monitors} />);
     expect(lastFrame()).toMatchSnapshot();
@@ -467,25 +686,27 @@ describe('Dashboard Component Snapshots', () => {
   });
 
   it('should render SSL monitor with expiring certificate (warning)', () => {
-    const monitors = [{
-      id: 1,
-      name: 'Expiring SSL',
-      type: 'ssl',
-      url: 'example.com',
-      interval: 3600,
-      uptime: '100.00',
-      lastDowntime: 'No downtime',
-      status: 'up',
-      latency: 200,
-      lastCheck: '5 minutes ago',
-      ssl: {
-        issuer: "Let's Encrypt",
-        subject: 'example.com',
-        validFrom: '2024-06-01',
-        validTo: '2024-12-15',
-        daysRemaining: 17
+    const monitors = [
+      {
+        id: 1,
+        name: 'Expiring SSL',
+        type: 'ssl',
+        url: 'example.com',
+        interval: 3600,
+        uptime: '100.00',
+        lastDowntime: 'No downtime',
+        status: 'up',
+        latency: 200,
+        lastCheck: '5 minutes ago',
+        ssl: {
+          issuer: "Let's Encrypt",
+          subject: 'example.com',
+          validFrom: '2024-06-01',
+          validTo: '2024-12-15',
+          daysRemaining: 17
+        }
       }
-    }];
+    ];
 
     const { lastFrame, unmount } = render(<SimpleDashboard monitors={monitors} />);
     expect(lastFrame()).toMatchSnapshot();
@@ -493,25 +714,27 @@ describe('Dashboard Component Snapshots', () => {
   });
 
   it('should render SSL monitor with critical expiry (<=7 days)', () => {
-    const monitors = [{
-      id: 1,
-      name: 'Critical SSL',
-      type: 'ssl',
-      url: 'urgent.com',
-      interval: 3600,
-      uptime: '100.00',
-      lastDowntime: 'No downtime',
-      status: 'up',
-      latency: 180,
-      lastCheck: '2 minutes ago',
-      ssl: {
-        issuer: 'Comodo',
-        subject: 'urgent.com',
-        validFrom: '2024-01-01',
-        validTo: '2024-12-01',
-        daysRemaining: 3
+    const monitors = [
+      {
+        id: 1,
+        name: 'Critical SSL',
+        type: 'ssl',
+        url: 'urgent.com',
+        interval: 3600,
+        uptime: '100.00',
+        lastDowntime: 'No downtime',
+        status: 'up',
+        latency: 180,
+        lastCheck: '2 minutes ago',
+        ssl: {
+          issuer: 'Comodo',
+          subject: 'urgent.com',
+          validFrom: '2024-01-01',
+          validTo: '2024-12-01',
+          daysRemaining: 3
+        }
       }
-    }];
+    ];
 
     const { lastFrame, unmount } = render(<SimpleDashboard monitors={monitors} />);
     expect(lastFrame()).toMatchSnapshot();
@@ -520,9 +743,51 @@ describe('Dashboard Component Snapshots', () => {
 
   it('should render mixed regular and SSL monitors', () => {
     const monitors = [
-      { id: 1, name: 'Main Site', type: 'http', url: 'https://mainsite.com', interval: 60, uptime: '99.95', lastDowntime: 'No downtime', status: 'up', latency: 95, lastCheck: '20 seconds ago', ssl: null },
-      { id: 2, name: 'API Server', type: 'http', url: 'https://api.mainsite.com', interval: 30, uptime: '99.90', lastDowntime: '1 day ago', status: 'up', latency: 45, lastCheck: '10 seconds ago', ssl: null },
-      { id: 3, name: 'Main SSL', type: 'ssl', url: 'mainsite.com', interval: 3600, uptime: '100.00', lastDowntime: 'No downtime', status: 'up', latency: 220, lastCheck: '30 minutes ago', ssl: { issuer: 'Cloudflare', subject: 'mainsite.com', validFrom: '2024-06-01', validTo: '2025-06-01', daysRemaining: 185 } }
+      {
+        id: 1,
+        name: 'Main Site',
+        type: 'http',
+        url: 'https://mainsite.com',
+        interval: 60,
+        uptime: '99.95',
+        lastDowntime: 'No downtime',
+        status: 'up',
+        latency: 95,
+        lastCheck: '20 seconds ago',
+        ssl: null
+      },
+      {
+        id: 2,
+        name: 'API Server',
+        type: 'http',
+        url: 'https://api.mainsite.com',
+        interval: 30,
+        uptime: '99.90',
+        lastDowntime: '1 day ago',
+        status: 'up',
+        latency: 45,
+        lastCheck: '10 seconds ago',
+        ssl: null
+      },
+      {
+        id: 3,
+        name: 'Main SSL',
+        type: 'ssl',
+        url: 'mainsite.com',
+        interval: 3600,
+        uptime: '100.00',
+        lastDowntime: 'No downtime',
+        status: 'up',
+        latency: 220,
+        lastCheck: '30 minutes ago',
+        ssl: {
+          issuer: 'Cloudflare',
+          subject: 'mainsite.com',
+          validFrom: '2024-06-01',
+          validTo: '2025-06-01',
+          daysRemaining: 185
+        }
+      }
     ];
 
     const { lastFrame, unmount } = render(<SimpleDashboard monitors={monitors} />);
@@ -532,9 +797,45 @@ describe('Dashboard Component Snapshots', () => {
 
   it('should show correct counts in header (up/down)', () => {
     const monitors = [
-      { id: 1, name: 'Up1', type: 'http', url: 'https://up1.com', interval: 60, uptime: '100', lastDowntime: 'No downtime', status: 'up', latency: 100, lastCheck: 'now', ssl: null },
-      { id: 2, name: 'Up2', type: 'http', url: 'https://up2.com', interval: 60, uptime: '100', lastDowntime: 'No downtime', status: 'up', latency: 100, lastCheck: 'now', ssl: null },
-      { id: 3, name: 'Down1', type: 'http', url: 'https://down1.com', interval: 60, uptime: '50', lastDowntime: 'now', status: 'down', latency: 0, lastCheck: 'now', ssl: null },
+      {
+        id: 1,
+        name: 'Up1',
+        type: 'http',
+        url: 'https://up1.com',
+        interval: 60,
+        uptime: '100',
+        lastDowntime: 'No downtime',
+        status: 'up',
+        latency: 100,
+        lastCheck: 'now',
+        ssl: null
+      },
+      {
+        id: 2,
+        name: 'Up2',
+        type: 'http',
+        url: 'https://up2.com',
+        interval: 60,
+        uptime: '100',
+        lastDowntime: 'No downtime',
+        status: 'up',
+        latency: 100,
+        lastCheck: 'now',
+        ssl: null
+      },
+      {
+        id: 3,
+        name: 'Down1',
+        type: 'http',
+        url: 'https://down1.com',
+        interval: 60,
+        uptime: '50',
+        lastDowntime: 'now',
+        status: 'down',
+        latency: 0,
+        lastCheck: 'now',
+        ssl: null
+      }
     ];
 
     const { lastFrame, unmount } = render(<SimpleDashboard monitors={monitors} />);
@@ -543,19 +844,21 @@ describe('Dashboard Component Snapshots', () => {
   });
 
   it('should maintain consistent column widths with long URLs', () => {
-    const monitors = [{
-      id: 1,
-      name: 'VeryLongMonitorNameThatShouldBeTruncated',
-      type: 'http',
-      url: 'https://very-long-subdomain.example.com/path/to/resource',
-      interval: 60,
-      uptime: '99.99',
-      lastDowntime: 'No downtime',
-      status: 'up',
-      latency: 100,
-      lastCheck: '10 seconds ago',
-      ssl: null
-    }];
+    const monitors = [
+      {
+        id: 1,
+        name: 'VeryLongMonitorNameThatShouldBeTruncated',
+        type: 'http',
+        url: 'https://very-long-subdomain.example.com/path/to/resource',
+        interval: 60,
+        uptime: '99.99',
+        lastDowntime: 'No downtime',
+        status: 'up',
+        latency: 100,
+        lastCheck: '10 seconds ago',
+        ssl: null
+      }
+    ];
 
     const { lastFrame, unmount } = render(<SimpleDashboard monitors={monitors} />);
     expect(lastFrame()).toMatchSnapshot();
@@ -590,7 +893,7 @@ describe('MonitorDetail Component Snapshots', () => {
       { status: 'up', timestamp: '2024-11-28 11:59:00', latency: 145 },
       { status: 'up', timestamp: '2024-11-28 11:58:00', latency: 160 },
       { status: 'down', timestamp: '2024-11-28 11:57:00', latency: 0 },
-      { status: 'up', timestamp: '2024-11-28 11:56:00', latency: 140 },
+      { status: 'up', timestamp: '2024-11-28 11:56:00', latency: 140 }
     ];
 
     const { lastFrame, unmount } = render(<SimpleMonitorDetail monitor={monitor} heartbeats={heartbeats} />);
@@ -611,7 +914,7 @@ describe('MonitorDetail Component Snapshots', () => {
       { status: 'down', timestamp: '2024-11-28 12:00:00', latency: 0 },
       { status: 'down', timestamp: '2024-11-28 11:59:30', latency: 0 },
       { status: 'down', timestamp: '2024-11-28 11:59:00', latency: 0 },
-      { status: 'up', timestamp: '2024-11-28 11:58:30', latency: 200 },
+      { status: 'up', timestamp: '2024-11-28 11:58:30', latency: 200 }
     ];
 
     const { lastFrame, unmount } = render(<SimpleMonitorDetail monitor={monitor} heartbeats={heartbeats} />);
@@ -624,7 +927,7 @@ describe('MonitorDetail Component Snapshots', () => {
     const heartbeats = [
       { status: 'up', timestamp: '2024-11-28 12:00:00', latency: 25 },
       { status: 'up', timestamp: '2024-11-28 11:59:30', latency: 28 },
-      { status: 'up', timestamp: '2024-11-28 11:59:00', latency: 22 },
+      { status: 'up', timestamp: '2024-11-28 11:59:00', latency: 22 }
     ];
 
     const { lastFrame, unmount } = render(<SimpleMonitorDetail monitor={monitor} heartbeats={heartbeats} />);
@@ -636,7 +939,7 @@ describe('MonitorDetail Component Snapshots', () => {
     const monitor = { id: 4, name: 'GitHub SSL', type: 'ssl', url: 'github.com', interval: 3600, webhook_url: null };
     const heartbeats = [
       { status: 'up', timestamp: '2024-11-28 12:00:00', latency: 250 },
-      { status: 'up', timestamp: '2024-11-28 11:00:00', latency: 245 },
+      { status: 'up', timestamp: '2024-11-28 11:00:00', latency: 245 }
     ];
     const sslCert = {
       issuer: 'DigiCert Inc',
@@ -648,13 +951,22 @@ describe('MonitorDetail Component Snapshots', () => {
       fingerprint: 'SHA256:AABBCCDD'
     };
 
-    const { lastFrame, unmount } = render(<SimpleMonitorDetail monitor={monitor} heartbeats={heartbeats} sslCert={sslCert} />);
+    const { lastFrame, unmount } = render(
+      <SimpleMonitorDetail monitor={monitor} heartbeats={heartbeats} sslCert={sslCert} />
+    );
     expect(lastFrame()).toMatchSnapshot();
     unmount();
   });
 
   it('should render SSL monitor detail - expiring certificate (warning)', () => {
-    const monitor = { id: 5, name: 'Expiring SSL', type: 'ssl', url: 'expiring.com', interval: 3600, webhook_url: null };
+    const monitor = {
+      id: 5,
+      name: 'Expiring SSL',
+      type: 'ssl',
+      url: 'expiring.com',
+      interval: 3600,
+      webhook_url: null
+    };
     const heartbeats = [{ status: 'up', timestamp: '2024-11-28 12:00:00', latency: 200 }];
     const sslCert = {
       issuer: "Let's Encrypt",
@@ -664,13 +976,22 @@ describe('MonitorDetail Component Snapshots', () => {
       days_remaining: 17
     };
 
-    const { lastFrame, unmount } = render(<SimpleMonitorDetail monitor={monitor} heartbeats={heartbeats} sslCert={sslCert} />);
+    const { lastFrame, unmount } = render(
+      <SimpleMonitorDetail monitor={monitor} heartbeats={heartbeats} sslCert={sslCert} />
+    );
     expect(lastFrame()).toMatchSnapshot();
     unmount();
   });
 
   it('should render SSL monitor detail - critical expiry (<=7 days)', () => {
-    const monitor = { id: 6, name: 'Critical SSL', type: 'ssl', url: 'critical.com', interval: 3600, webhook_url: null };
+    const monitor = {
+      id: 6,
+      name: 'Critical SSL',
+      type: 'ssl',
+      url: 'critical.com',
+      interval: 3600,
+      webhook_url: null
+    };
     const heartbeats = [{ status: 'up', timestamp: '2024-11-28 12:00:00', latency: 180 }];
     const sslCert = {
       issuer: 'Comodo',
@@ -680,7 +1001,9 @@ describe('MonitorDetail Component Snapshots', () => {
       days_remaining: 3
     };
 
-    const { lastFrame, unmount } = render(<SimpleMonitorDetail monitor={monitor} heartbeats={heartbeats} sslCert={sslCert} />);
+    const { lastFrame, unmount } = render(
+      <SimpleMonitorDetail monitor={monitor} heartbeats={heartbeats} sslCert={sslCert} />
+    );
     expect(lastFrame()).toMatchSnapshot();
     unmount();
   });
@@ -696,7 +1019,9 @@ describe('MonitorDetail Component Snapshots', () => {
       days_remaining: -330
     };
 
-    const { lastFrame, unmount } = render(<SimpleMonitorDetail monitor={monitor} heartbeats={heartbeats} sslCert={sslCert} />);
+    const { lastFrame, unmount } = render(
+      <SimpleMonitorDetail monitor={monitor} heartbeats={heartbeats} sslCert={sslCert} />
+    );
     expect(lastFrame()).toMatchSnapshot();
     unmount();
   });
@@ -718,7 +1043,14 @@ describe('MonitorDetail Component Snapshots', () => {
   });
 
   it('should render with no heartbeat data', () => {
-    const monitor = { id: 9, name: 'New Monitor', type: 'http', url: 'https://new.example.com', interval: 60, webhook_url: null };
+    const monitor = {
+      id: 9,
+      name: 'New Monitor',
+      type: 'http',
+      url: 'https://new.example.com',
+      interval: 60,
+      webhook_url: null
+    };
 
     const { lastFrame, unmount } = render(<SimpleMonitorDetail monitor={monitor} heartbeats={[]} />);
     expect(lastFrame()).toMatchSnapshot();
@@ -726,12 +1058,19 @@ describe('MonitorDetail Component Snapshots', () => {
   });
 
   it('should render high latency monitor (>500ms)', () => {
-    const monitor = { id: 10, name: 'Slow Site', type: 'http', url: 'https://slow.example.com', interval: 60, webhook_url: null };
+    const monitor = {
+      id: 10,
+      name: 'Slow Site',
+      type: 'http',
+      url: 'https://slow.example.com',
+      interval: 60,
+      webhook_url: null
+    };
     const heartbeats = [
       { status: 'up', timestamp: '2024-11-28 12:00:00', latency: 850 },
       { status: 'up', timestamp: '2024-11-28 11:59:00', latency: 920 },
       { status: 'up', timestamp: '2024-11-28 11:58:00', latency: 780 },
-      { status: 'up', timestamp: '2024-11-28 11:57:00', latency: 650 },
+      { status: 'up', timestamp: '2024-11-28 11:57:00', latency: 650 }
     ];
 
     const { lastFrame, unmount } = render(<SimpleMonitorDetail monitor={monitor} heartbeats={heartbeats} />);
@@ -752,7 +1091,7 @@ describe('MonitorDetail Component Snapshots', () => {
     const heartbeats = [
       { status: 'up', timestamp: '2024-11-28 12:00:00', latency: 120 },
       { status: 'up', timestamp: '2024-11-28 11:59:30', latency: 115 },
-      { status: 'up', timestamp: '2024-11-28 11:59:00', latency: 125 },
+      { status: 'up', timestamp: '2024-11-28 11:59:00', latency: 125 }
     ];
 
     const { lastFrame, unmount } = render(<SimpleMonitorDetail monitor={monitor} heartbeats={heartbeats} />);
@@ -772,7 +1111,7 @@ describe('MonitorDetail Component Snapshots', () => {
     };
     const heartbeats = [
       { status: 'up', timestamp: '2024-11-28 12:00:00', latency: 200 },
-      { status: 'up', timestamp: '2024-11-28 11:00:00', latency: 195 },
+      { status: 'up', timestamp: '2024-11-28 11:00:00', latency: 195 }
     ];
     const sslCert = {
       issuer: 'DigiCert Inc',
@@ -782,7 +1121,9 @@ describe('MonitorDetail Component Snapshots', () => {
       days_remaining: 79
     };
 
-    const { lastFrame, unmount } = render(<SimpleMonitorDetail monitor={monitor} heartbeats={heartbeats} sslCert={sslCert} />);
+    const { lastFrame, unmount } = render(
+      <SimpleMonitorDetail monitor={monitor} heartbeats={heartbeats} sslCert={sslCert} />
+    );
     expect(lastFrame()).toMatchSnapshot();
     unmount();
   });

--- a/tests/ui/snapshot.test.js
+++ b/tests/ui/snapshot.test.js
@@ -236,12 +236,12 @@ const SimpleDashboard = ({ monitors = [], groupFilter = null, groups = [] }) => 
                 Type
               </Text>
             </Box>
-            <Box width="9%">
+            <Box width="10%">
               <Text bold color="blue">
                 Status
               </Text>
             </Box>
-            <Box width="9%">
+            <Box width="10%">
               <Text bold color="blue">
                 Latency
               </Text>
@@ -251,7 +251,7 @@ const SimpleDashboard = ({ monitors = [], groupFilter = null, groups = [] }) => 
                 Uptime (24h)
               </Text>
             </Box>
-            <Box width="22%">
+            <Box width="20%">
               <Text bold color="blue">
                 Last Downtime
               </Text>
@@ -923,7 +923,14 @@ describe('MonitorDetail Component Snapshots', () => {
   });
 
   it('should render ICMP monitor detail', () => {
-    const monitor = { id: 2, name: 'Google DNS', type: 'icmp', url: '8.8.8.8', interval: 30, webhook_url: null };
+    const monitor = {
+      id: 2,
+      name: 'Google DNS',
+      type: 'icmp',
+      url: '8.8.8.8',
+      interval: 30,
+      webhook_url: null
+    };
     const heartbeats = [
       { status: 'up', timestamp: '2024-11-28 12:00:00', latency: 25 },
       { status: 'up', timestamp: '2024-11-28 11:59:30', latency: 28 },
@@ -936,7 +943,14 @@ describe('MonitorDetail Component Snapshots', () => {
   });
 
   it('should render SSL monitor detail - valid certificate', () => {
-    const monitor = { id: 4, name: 'GitHub SSL', type: 'ssl', url: 'github.com', interval: 3600, webhook_url: null };
+    const monitor = {
+      id: 4,
+      name: 'GitHub SSL',
+      type: 'ssl',
+      url: 'github.com',
+      interval: 3600,
+      webhook_url: null
+    };
     const heartbeats = [
       { status: 'up', timestamp: '2024-11-28 12:00:00', latency: 250 },
       { status: 'up', timestamp: '2024-11-28 11:00:00', latency: 245 }
@@ -1009,7 +1023,14 @@ describe('MonitorDetail Component Snapshots', () => {
   });
 
   it('should render SSL monitor detail - invalid certificate', () => {
-    const monitor = { id: 7, name: 'Expired SSL', type: 'ssl', url: 'expired.com', interval: 3600, webhook_url: null };
+    const monitor = {
+      id: 7,
+      name: 'Expired SSL',
+      type: 'ssl',
+      url: 'expired.com',
+      interval: 3600,
+      webhook_url: null
+    };
     const heartbeats = [{ status: 'down', timestamp: '2024-11-28 12:00:00', latency: 0 }];
     const sslCert = {
       issuer: 'Unknown',

--- a/tests/utils/helpers.test.js
+++ b/tests/utils/helpers.test.js
@@ -10,10 +10,12 @@ function renderSparkline(values, width = 60) {
   const min = Math.min(...v);
   const range = max - min || 1;
 
-  return v.map(num => {
-    const p = Math.floor(((num - min) / range) * (bars.length - 1));
-    return bars[p] || bars[0];
-  }).join('');
+  return v
+    .map(num => {
+      const p = Math.floor(((num - min) / range) * (bars.length - 1));
+      return bars[p] || bars[0];
+    })
+    .join('');
 }
 
 describe('Sparkline Renderer', () => {
@@ -60,7 +62,9 @@ describe('Sparkline Renderer', () => {
   });
 
   it('respects width parameter', () => {
-    const values = Array(100).fill(0).map((_, i) => i);
+    const values = Array(100)
+      .fill(0)
+      .map((_, i) => i);
     const result = renderSparkline(values, 20);
     expect(result.length).toBe(20);
   });
@@ -178,32 +182,19 @@ describe('Uptime Calculation', () => {
   });
 
   it('calculates correct percentage', () => {
-    const heartbeats = [
-      { status: 'up' },
-      { status: 'up' },
-      { status: 'up' },
-      { status: 'down' }
-    ];
+    const heartbeats = [{ status: 'up' }, { status: 'up' }, { status: 'up' }, { status: 'down' }];
     expect(calculateUptime(heartbeats)).toBe('75.00');
   });
 
   it('handles mixed statuses', () => {
-    const heartbeats = [
-      { status: 'up' },
-      { status: 'down' },
-      { status: 'up' },
-      { status: 'down' },
-      { status: 'up' }
-    ];
+    const heartbeats = [{ status: 'up' }, { status: 'down' }, { status: 'up' }, { status: 'down' }, { status: 'up' }];
     expect(calculateUptime(heartbeats)).toBe('60.00');
   });
 });
 
 describe('Latency Statistics', () => {
   function calculateLatencyStats(heartbeats) {
-    const latencies = heartbeats
-      .filter(h => typeof h.latency === 'number')
-      .map(h => h.latency);
+    const latencies = heartbeats.filter(h => typeof h.latency === 'number').map(h => h.latency);
 
     if (latencies.length === 0) {
       return { min: 0, max: 0, avg: 0, p95: 0 };
@@ -235,24 +226,14 @@ describe('Latency Statistics', () => {
   });
 
   it('calculates correct min/max', () => {
-    const heartbeats = [
-      { latency: 50 },
-      { latency: 150 },
-      { latency: 100 },
-      { latency: 200 },
-      { latency: 75 }
-    ];
+    const heartbeats = [{ latency: 50 }, { latency: 150 }, { latency: 100 }, { latency: 200 }, { latency: 75 }];
     const stats = calculateLatencyStats(heartbeats);
     expect(stats.min).toBe(50);
     expect(stats.max).toBe(200);
   });
 
   it('calculates correct average', () => {
-    const heartbeats = [
-      { latency: 100 },
-      { latency: 200 },
-      { latency: 300 }
-    ];
+    const heartbeats = [{ latency: 100 }, { latency: 200 }, { latency: 300 }];
     const stats = calculateLatencyStats(heartbeats);
     expect(stats.avg).toBe(200);
   });
@@ -270,7 +251,9 @@ describe('Latency Statistics', () => {
   });
 
   it('calculates p95 correctly', () => {
-    const heartbeats = Array(20).fill(0).map((_, i) => ({ latency: (i + 1) * 10 }));
+    const heartbeats = Array(20)
+      .fill(0)
+      .map((_, i) => ({ latency: (i + 1) * 10 }));
     const stats = calculateLatencyStats(heartbeats);
     expect(stats.p95).toBe(200);
   });


### PR DESCRIPTION
Hi,

thanks for this awesome software. Great work!

### Problem

I get a few false positives during the day especially when switching between vpns.
We can avoid it if we can configure retries and only send notifications when the retries are reached something other monitor solutions like uptime-kuma has implemented.

### Solution

This PR introduces a new `--retries,-r` property for add and edit of monitors.

If this option is specified the notification is only send then the retries are reached or the monitor is up again.
I also added an editorconfig and a prettier format to minimize the formatting code changes and make it easier to contribute to the project.

Would be great if that can be merged.
If I should change something let me know.

Have a great day!